### PR TITLE
docs(permission): GrantTarget vs ResolvedTarget 의도적 분리 명시

### DIFF
--- a/docs/permission/grants.md
+++ b/docs/permission/grants.md
@@ -57,6 +57,27 @@ interface GrantTarget {
 }
 ```
 
+> **`GrantTarget` (저장형) ≠ `ResolvedTarget` / `PermissionTarget` (런타임형) — 의도적 분리.**
+>
+> Storage 측 `GrantTarget` (zod `GrantTargetSchema`, `src/types/permission.ts`)
+> 의 `kind:'global'` variant 는 **`value` 필드 없음** — "모든 곳" 의미가
+> shape 자체로 명시. 한편 런타임 `ResolvedTarget` (`src/permission/Targets.ts:17`)
+> + tool 측 `PermissionTarget` 은 `value: string` 을 **필수** 로 가지며,
+> `kind:'global'` 시 빈 문자열 사용. 이는 ResolvedTarget 이 tool 호출 시점에
+> 해석된 *실제* target (path/url/domain 의 구체 값) 을 담는 vehicle 이라
+> uniform 한 `value` 슬롯이 더 편함. v1.1.0 도입 시 의도적 결정.
+>
+> 두 shape 변환은 `resolvedToGrantTarget()` adapter 가 담당
+> (`src/permission/Targets.ts`). 새 callsite 가 grant 를 저장할 땐 반드시
+> adapter 통과 — 직접 `{ kind:'global', value:'' }` 를 `GrantTarget` 으로
+> 캐스팅하면 zod parse 시 strip 되어 통과하지만 의미상 잘못됨.
+>
+> 회귀 가드: `tests/storage/permissionGrants.idText.test.ts` 의 fixture 는
+> `{ kind:'global' }` (no value) 사용 — canonical storage shape.
+>
+> *근거*: Codex Q13 외부 검토 (2026-05-07) + AI slop cleaner 종료 보고
+> (false-completion 위험 정정).
+
 ### 예시
 
 ```json


### PR DESCRIPTION
## Summary

PR #6 의 `d341a7f` (test fixture 정합 fix) 이후 ai-slop-cleaner 가 source 측 동일 shape 정합을 시도 → typecheck fail 로 back out. Codex Q13 외부 검증이 "두 shape 분리는 의도적 (v1.1.0)" 확인 + Claude 의 보고를 "false-completion 위험" 으로 지적.

본 PR 은 `docs/permission/grants.md` 의 `GrantTarget` 섹션 직후에 두 shape 의 의도적 분리 + adapter 책임 명시. 코드 변경 없음.

## Codex Q13 권고 적용

- **C (adapter 명시화)** 권고에 따라 doc 으로 boundary contract 명문화.
- A/B (interface optional / schema default) 는 보류 — 별도 architecture 결정 필요.

## Test plan

- [x] 코드 변경 없음 — doc 1 파일.
- [x] baseline 2056/0 유지 (직전 PR #6 머지 시점과 동일).
- [ ] 후속: 새 callsite review 시 본 doc 참조 확인.

## Commit

```
26f73c7 docs(permission/grants): GrantTarget vs ResolvedTarget/PermissionTarget 의도적 분리 명시
```

## 관련

- PR #6 머지 직후 follow-up.
- Codex Q13 artifact: `.omc/artifacts/ask/codex-q13-slop-cleaner-review-result.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)