### PR TITLE
ci/cleanup — workspaceConflict macOS + 4 lint fixes

### DIFF
--- a/e2e/_drive.spec.ts
+++ b/e2e/_drive.spec.ts
@@ -71,13 +71,14 @@ test.describe('drive', () => {
       const original = dialog.showOpenDialog.bind(dialog);
       // @ts-expect-error — 글로벌 sentinel 로 호출 횟수 캡처
       globalThis.__pickCalls = 0;
+      // original 은 안 부른다 — 실제 OS 다이얼로그가 뜨면 테스트가 멈춘다.
+      // void 로 unused 경고만 회피.
+      void original;
       dialog.showOpenDialog = (async () => {
-        // @ts-expect-error
+        // @ts-expect-error -- 위에서 globalThis.__pickCalls 를 number 로 주입.
         globalThis.__pickCalls += 1;
         // 사용자가 dialog 를 cancel 한 것처럼 응답.
         return { canceled: true, filePaths: [] };
-        // original 은 안 부른다 — 실제 OS 다이얼로그가 뜨면 테스트가 멈춘다.
-        void original;
       }) as typeof dialog.showOpenDialog;
     });
 
@@ -89,7 +90,7 @@ test.describe('drive', () => {
     await window.waitForTimeout(500);
 
     const calls = await app.evaluate(() => {
-      // @ts-expect-error
+      // @ts-expect-error -- e2e fixture 가 main process 에서 globalThis.__pickCalls 를 주입 (production X).
       return globalThis.__pickCalls as number;
     });
 

--- a/examples/plugins/cost-limit-hook/index.js
+++ b/examples/plugins/cost-limit-hook/index.js
@@ -1,3 +1,4 @@
+/* global ctx */
 // cost-limit-hook — Dreampia-Dev Plugin Loader sample (v1.1.24).
 //
 // Spec: docs/v1.x-roadmap.md (P1 v1.1.x Plugin Loader / hook 시스템).

--- a/src/main/BrowserManager.ts
+++ b/src/main/BrowserManager.ts
@@ -463,7 +463,9 @@ export class BrowserManager {
    * Electron NativeImage 의 `toPNG()` 는 Buffer 반환. base64 변환은 caller
    * 가 결정 가능하지만 IPC 직렬화 호환을 위해 본 메서드는 base64 string 반환.
    */
-  async captureTab(tab_id: string): Promise<{ png_base64: string; width: number; height: number } | null> {
+  async captureTab(
+    tab_id: string
+  ): Promise<{ png_base64: string; width: number; height: number } | null> {
     const tab = this.tabs.get(tab_id);
     if (!tab) return null;
     const wc = tab.view.webContents as {

--- a/src/main/CostGate.ts
+++ b/src/main/CostGate.ts
@@ -53,9 +53,7 @@ export type CostGateOutcome =
     }
   | {
       kind: 'block';
-      reason:
-        | 'limit_exceeded'
-        | 'unknown_model_under_limit';
+      reason: 'limit_exceeded' | 'unknown_model_under_limit';
       /** 사용자에게 보여줄 i18n key 또는 메시지. */
       hint: string;
       /** 사용자가 한도 / 사용량 직접 보도록. */

--- a/src/main/IpcPermissionConfirmer.ts
+++ b/src/main/IpcPermissionConfirmer.ts
@@ -47,12 +47,7 @@ export interface IpcPermissionConfirmerOptions {
    * 시 같은 ID 의 webContents 만 수락. send 실패 시 -1 같은 sentinel 권고 X —
    * 단순 false 반환 (기존 호환).
    */
-  send: (
-    channel: string,
-    payload: unknown
-  ) =>
-    | boolean
-    | { sent: boolean; web_contents_id: number };
+  send: (channel: string, payload: unknown) => boolean | { sent: boolean; web_contents_id: number };
   /** Auto deny timeout. default 60s. */
   timeout_ms?: number;
 }
@@ -167,9 +162,7 @@ export class IpcPermissionConfirmer implements PermissionConfirmer {
   getPendingRequests(senderWebContentsId?: number): PermissionRequest[] {
     const all = Array.from(this.pending.values());
     if (senderWebContentsId === undefined) return all.map((d) => d.request);
-    return all
-      .filter((d) => d.webContentsId === senderWebContentsId)
-      .map((d) => d.request);
+    return all.filter((d) => d.webContentsId === senderWebContentsId).map((d) => d.request);
   }
 
   /**

--- a/src/main/automation/AutomationManager.ts
+++ b/src/main/automation/AutomationManager.ts
@@ -351,9 +351,7 @@ export function getAutomationManager(
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          console.warn(
-            `[AutomationManager] persisted rule '${r.name}' rejected: ${msg}`
-          );
+          console.warn(`[AutomationManager] persisted rule '${r.name}' rejected: ${msg}`);
         }
       }
     } catch {

--- a/src/main/automation/handlers/HandlerRegistry.ts
+++ b/src/main/automation/handlers/HandlerRegistry.ts
@@ -30,9 +30,7 @@ export interface HandlerResult {
   error?: string;
 }
 
-export type AutomationHandler = (
-  ctx: HandlerContext
-) => Promise<HandlerResult>;
+export type AutomationHandler = (ctx: HandlerContext) => Promise<HandlerResult>;
 
 /**
  * Handler 식별자 → 실행 함수 lookup.

--- a/src/main/automation/handlers/index.ts
+++ b/src/main/automation/handlers/index.ts
@@ -5,23 +5,10 @@
  * 외부 (plugin / test) 에서 추가 handler 등록은 `handlerRegistry.register()`.
  */
 
-import {
-  handlerRegistry,
-  noopLogHandler,
-  NOOP_LOG_HANDLER_NAME,
-} from './HandlerRegistry';
-import {
-  llmPromptHandler,
-  LLM_PROMPT_HANDLER_NAME,
-} from './llmPromptHandler';
-import {
-  shellExecHandler,
-  SHELL_EXEC_HANDLER_NAME,
-} from './shellExecHandler';
-import {
-  ipcTriggerHandler,
-  IPC_TRIGGER_HANDLER_NAME,
-} from './ipcTriggerHandler';
+import { handlerRegistry, noopLogHandler, NOOP_LOG_HANDLER_NAME } from './HandlerRegistry';
+import { llmPromptHandler, LLM_PROMPT_HANDLER_NAME } from './llmPromptHandler';
+import { shellExecHandler, SHELL_EXEC_HANDLER_NAME } from './shellExecHandler';
+import { ipcTriggerHandler, IPC_TRIGGER_HANDLER_NAME } from './ipcTriggerHandler';
 
 let registered = false;
 
@@ -53,8 +40,4 @@ export {
   IPC_TRIGGER_HANDLER_NAME,
 };
 export { setIpcTriggerEmitter } from './ipcTriggerHandler';
-export type {
-  AutomationHandler,
-  HandlerContext,
-  HandlerResult,
-} from './HandlerRegistry';
+export type { AutomationHandler, HandlerContext, HandlerResult } from './HandlerRegistry';

--- a/src/main/automation/handlers/ipcTriggerHandler.ts
+++ b/src/main/automation/handlers/ipcTriggerHandler.ts
@@ -82,8 +82,6 @@ export const ipcTriggerHandler: AutomationHandler = async (ctx) => {
   }
 
   const summary =
-    payload === undefined
-      ? channel
-      : `${channel} ${truncateOutput(JSON.stringify(payload), 200)}`;
+    payload === undefined ? channel : `${channel} ${truncateOutput(JSON.stringify(payload), 200)}`;
   return { ok: true, output: `[ipc] ${summary}` };
 };

--- a/src/main/automation/handlers/llmPromptHandler.ts
+++ b/src/main/automation/handlers/llmPromptHandler.ts
@@ -36,12 +36,8 @@ export const llmPromptHandler: AutomationHandler = async (ctx) => {
     return { ok: false, error: 'prompt required (config.prompt: string)' };
   }
   const model =
-    typeof cfg['model'] === 'string' && cfg['model'].length > 0
-      ? cfg['model']
-      : DEFAULT_MODEL;
-  const cwd = typeof cfg['cwd'] === 'string' && cfg['cwd'].length > 0
-    ? cfg['cwd']
-    : process.cwd();
+    typeof cfg['model'] === 'string' && cfg['model'].length > 0 ? cfg['model'] : DEFAULT_MODEL;
+  const cwd = typeof cfg['cwd'] === 'string' && cfg['cwd'].length > 0 ? cfg['cwd'] : process.cwd();
 
   const turn: Turn = {
     id: `auto-${ctx.rule_name}-${Date.now()}` as TurnId,
@@ -52,13 +48,7 @@ export const llmPromptHandler: AutomationHandler = async (ctx) => {
   };
 
   try {
-    const { provider } = await getDefaultProvider(
-      model,
-      undefined,
-      cwd,
-      'workspace_write',
-      'auto'
-    );
+    const { provider } = await getDefaultProvider(model, undefined, cwd, 'workspace_write', 'auto');
 
     let text = '';
     let errored: string | null = null;

--- a/src/main/automation/handlers/shellExecHandler.ts
+++ b/src/main/automation/handlers/shellExecHandler.ts
@@ -53,8 +53,7 @@ export function setShellSpawnForTesting(fn: ShellSpawnFn | null): void {
  * Test 용 settings override. Production 은 readSettings() 호출.
  * null 이면 다시 readSettings() 사용.
  */
-let settingsOverrideForTesting: { automation_shell_enabled?: boolean } | null =
-  null;
+let settingsOverrideForTesting: { automation_shell_enabled?: boolean } | null = null;
 
 export function setShellSettingsForTesting(
   override: { automation_shell_enabled?: boolean } | null
@@ -90,23 +89,17 @@ export const shellExecHandler: AutomationHandler = async (ctx) => {
   const args = Array.isArray(cfg['args'])
     ? cfg['args'].filter((a): a is string => typeof a === 'string')
     : [];
-  const cwd =
-    typeof cfg['cwd'] === 'string' && cfg['cwd'].length > 0
-      ? cfg['cwd']
-      : undefined;
+  const cwd = typeof cfg['cwd'] === 'string' && cfg['cwd'].length > 0 ? cfg['cwd'] : undefined;
   const timeoutMs =
     typeof cfg['timeout_ms'] === 'number' && cfg['timeout_ms'] > 0
       ? Math.floor(cfg['timeout_ms'])
       : DEFAULT_TIMEOUT_MS;
   const extraEnv =
-    cfg['env'] !== null &&
-    typeof cfg['env'] === 'object' &&
-    !Array.isArray(cfg['env'])
+    cfg['env'] !== null && typeof cfg['env'] === 'object' && !Array.isArray(cfg['env'])
       ? (cfg['env'] as Record<string, string>)
       : {};
 
-  const spawnFn: ShellSpawnFn =
-    injectedSpawn ?? ((cmd, a, o) => nodeSpawn(cmd, a as string[], o));
+  const spawnFn: ShellSpawnFn = injectedSpawn ?? ((cmd, a, o) => nodeSpawn(cmd, a as string[], o));
 
   return new Promise((resolve) => {
     let child: ChildProcess;

--- a/src/main/compare/orchestrator.ts
+++ b/src/main/compare/orchestrator.ts
@@ -30,12 +30,7 @@ import type { PermissionLevel } from '@/types/permission';
 import type { Turn, TurnId } from '@/types';
 import { newTurnId, nowIso } from '@/types';
 import type { StreamEvent, StreamingProvider } from '@/providers';
-import {
-  CompareStore,
-  type CompareRun,
-  type CompareSide,
-  type CompareSideStatus,
-} from '@/storage';
+import { CompareStore, type CompareRun, type CompareSide, type CompareSideStatus } from '@/storage';
 
 // ────────────────────────────────────────────────────────────
 // Public types

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,20 +10,10 @@ import { autoUpdater } from 'electron-updater';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import {
-  registerIpcHandlers,
-  shutdownAiHandlers,
-  shutdownCompareHandlers,
-} from './ipc';
+import { registerIpcHandlers, shutdownAiHandlers, shutdownCompareHandlers } from './ipc';
 import { BrowserManager } from './BrowserManager';
 import { McpManager, createSettingsAdapter } from './mcp';
-import {
-  AuditLogStore,
-  CompareStore,
-  LeaderElection,
-  SessionStore,
-  UsageStore,
-} from '@/storage';
+import { AuditLogStore, CompareStore, LeaderElection, SessionStore, UsageStore } from '@/storage';
 import { ShellRunTool, ToolQueue, ToolRegistry, type ToolAuditEvent } from '@/tools';
 import { getDefaultProvider } from '@/providers/auto';
 import type { ProviderFactory } from './compare/orchestrator';
@@ -251,9 +241,7 @@ app.whenReady().then(async () => {
       enabled,
     });
     if (result.sentry) {
-      console.info(
-        `[main] Sentry telemetry initialized (enabled=${String(enabled)})`
-      );
+      console.info(`[main] Sentry telemetry initialized (enabled=${String(enabled)})`);
     } else {
       console.debug(`[main] Telemetry: ${result.reason ?? 'console fallback'}`);
     }
@@ -390,8 +378,7 @@ app.whenReady().then(async () => {
         event: event.event,
         capability: 'PLUGIN',
         target_json: JSON.stringify({ plugin_dir: event.plugin_dir }),
-        decision_reason:
-          event.event === 'plugin.loaded' ? 'loaded' : 'invalid',
+        decision_reason: event.event === 'plugin.loaded' ? 'loaded' : 'invalid',
         ...(event.event !== 'plugin.loaded' && {
           outcome: 'skipped',
           ...(event.reason !== undefined && { error: event.reason }),
@@ -496,8 +483,7 @@ app.whenReady().then(async () => {
           tool_name: event.tool_name,
           warnings: event.warnings,
         }),
-        decision_reason:
-          event.event === 'mcp.input_schema_converted' ? 'converted' : 'unconverted',
+        decision_reason: event.event === 'mcp.input_schema_converted' ? 'converted' : 'unconverted',
         outcome: event.warnings.length > 0 ? 'partial' : 'ok',
         ...(event.warnings.length > 0 && { error: event.warnings.join('; ') }),
       });
@@ -512,13 +498,7 @@ app.whenReady().then(async () => {
   // via getDefaultProvider so that user's wizard preference (claude / codex /
   // mock override) still applies, but model prefix routing forces the chosen
   // CLI per side. We pass `userDefaultProvider='auto'` so model prefix wins.
-  const compareFactory: ProviderFactory = async (
-    side,
-    model,
-    signal,
-    cwd,
-    permissionLevel
-  ) => {
+  const compareFactory: ProviderFactory = async (side, model, signal, cwd, permissionLevel) => {
     const result = await getDefaultProvider(model, signal, cwd, permissionLevel, 'auto');
     void side;
     return { provider: result.provider, source: result.source };
@@ -594,17 +574,12 @@ app.whenReady().then(async () => {
   // mainWindow.webContents.send 로 자동화 rule 이 renderer 에 IPC 발사.
   // window 가 destroyed 되면 silent drop (다음 fire 시 재시도).
   void (async () => {
-    const { setIpcTriggerEmitter } = await import(
-      './automation/handlers/ipcTriggerHandler'
-    );
+    const { setIpcTriggerEmitter } = await import('./automation/handlers/ipcTriggerHandler');
     setIpcTriggerEmitter((channel, payload) => {
       const win = mainWindow;
       if (win === null) return;
       try {
-        if (
-          'isDestroyed' in win &&
-          (win as { isDestroyed?: () => boolean }).isDestroyed?.()
-        ) {
+        if ('isDestroyed' in win && (win as { isDestroyed?: () => boolean }).isDestroyed?.()) {
           return;
         }
         win.webContents.send(channel, payload);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,14 +12,7 @@
  * include absolute paths) into the renderer.
  */
 
-import {
-  app,
-  BrowserWindow,
-  dialog,
-  ipcMain,
-  type App,
-  type IpcMainInvokeEvent,
-} from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, type App, type IpcMainInvokeEvent } from 'electron';
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
@@ -351,12 +344,7 @@ const ListFilesArgsSchema = z
   .object({
     workspace_root: z.string().min(1),
     ignore_patterns: z.array(z.string()).optional(),
-    max_files: z
-      .number()
-      .int()
-      .positive()
-      .max(FILE_LIST_HARD_MAX_FILES)
-      .optional(),
+    max_files: z.number().int().positive().max(FILE_LIST_HARD_MAX_FILES).optional(),
   })
   .strict();
 
@@ -364,12 +352,7 @@ const ReadFileArgsSchema = z
   .object({
     workspace_root: z.string().min(1),
     rel_path: z.string().min(1),
-    max_bytes: z
-      .number()
-      .int()
-      .positive()
-      .max(FILE_READ_HARD_MAX_BYTES)
-      .optional(),
+    max_bytes: z.number().int().positive().max(FILE_READ_HARD_MAX_BYTES).optional(),
   })
   .strict();
 
@@ -428,8 +411,20 @@ function compileGlob(pattern: string): RegExp {
       re += '[^/]';
       continue;
     }
-    if (ch === '.' || ch === '+' || ch === '(' || ch === ')' || ch === '|' || ch === '^' ||
-        ch === '$' || ch === '{' || ch === '}' || ch === '[' || ch === ']' || ch === '\\') {
+    if (
+      ch === '.' ||
+      ch === '+' ||
+      ch === '(' ||
+      ch === ')' ||
+      ch === '|' ||
+      ch === '^' ||
+      ch === '$' ||
+      ch === '{' ||
+      ch === '}' ||
+      ch === '[' ||
+      ch === ']' ||
+      ch === '\\'
+    ) {
       re += '\\' + ch;
       continue;
     }
@@ -467,10 +462,7 @@ function isIgnored(relPath: string, compiledPatterns: ReadonlyArray<RegExp>): bo
  * Throws "path traversal" 메시지의 Error 가 발생하면 호출 측 try/catch 가
  * `Result<never>` 의 fail 로 변환한다 (renderer 는 string 만 받음).
  */
-async function resolveInsideWorkspace(
-  workspaceRoot: string,
-  relPath: string
-): Promise<string> {
+async function resolveInsideWorkspace(workspaceRoot: string, relPath: string): Promise<string> {
   // Step 1: workspace root 자체의 realpath (예: macOS 의 /tmp → /private/tmp,
   // Windows junction `C:\Dev\분석` 의 8.3 short path / junction alias 등도
   // 동일한 normalized form 으로 만든다).
@@ -498,9 +490,7 @@ async function resolveInsideWorkspace(
   }
 
   if (realTarget !== root && !realTarget.startsWith(root + sep)) {
-    throw new Error(
-      'path traversal: symlink/junction target resolves outside workspace_root'
-    );
+    throw new Error('path traversal: symlink/junction target resolves outside workspace_root');
   }
   return realTarget;
 }
@@ -664,15 +654,8 @@ export function registerIpcHandlers(
     try {
       // v0.3.0 — wizard 또는 설정에서 호출. Zod 스키마 대신 명시적 enum
       // 검증 — 작은 string union 에 schema 가 과하다.
-      if (
-        raw !== 'auto' &&
-        raw !== 'claude' &&
-        raw !== 'codex' &&
-        raw !== 'mock'
-      ) {
-        throw new Error(
-          'default_provider must be one of: auto, claude, codex, mock'
-        );
+      if (raw !== 'auto' && raw !== 'claude' && raw !== 'codex' && raw !== 'mock') {
+        throw new Error('default_provider must be one of: auto, claude, codex, mock');
       }
       writeSettings({ default_provider: raw });
       return ok(undefined);
@@ -715,10 +698,7 @@ export function registerIpcHandlers(
 
   ipcMain.handle('app:set-theme', (_evt, raw: unknown): Result<void> => {
     try {
-      if (
-        typeof raw !== 'string' ||
-        !(THEME_VALUES as readonly string[]).includes(raw)
-      ) {
+      if (typeof raw !== 'string' || !(THEME_VALUES as readonly string[]).includes(raw)) {
         throw new Error(`theme must be one of: ${THEME_VALUES.join(', ')}`);
       }
       writeSettings({ theme: raw as ThemeChoice });
@@ -741,10 +721,7 @@ export function registerIpcHandlers(
 
   ipcMain.handle('app:set-language', (_evt, raw: unknown): Result<void> => {
     try {
-      if (
-        typeof raw !== 'string' ||
-        !(LANGUAGE_VALUES as readonly string[]).includes(raw)
-      ) {
+      if (typeof raw !== 'string' || !(LANGUAGE_VALUES as readonly string[]).includes(raw)) {
         throw new Error(`language must be one of: ${LANGUAGE_VALUES.join(', ')}`);
       }
       writeSettings({ language: raw as LanguageChoice });
@@ -797,11 +774,14 @@ export function registerIpcHandlers(
         };
         return ok({
           anthropic: {
-            present: typeof settings.api_key_anthropic === 'string' && settings.api_key_anthropic.length > 0,
+            present:
+              typeof settings.api_key_anthropic === 'string' &&
+              settings.api_key_anthropic.length > 0,
             preview: previewOf(settings.api_key_anthropic),
           },
           openai: {
-            present: typeof settings.api_key_openai === 'string' && settings.api_key_openai.length > 0,
+            present:
+              typeof settings.api_key_openai === 'string' && settings.api_key_openai.length > 0,
             preview: previewOf(settings.api_key_openai),
           },
         });
@@ -842,45 +822,39 @@ export function registerIpcHandlers(
   // v0.10.0 — Settings 모달 [단축키] 탭. 사용자 지정 매핑 (action → combo).
   // GET 은 settings.json 의 keyboard_shortcut_overrides 를 그대로 반환 — 미설정
   // 시 빈 object. Renderer 의 useKeyboardShortcuts 가 default 와 merge.
-  ipcMain.handle(
-    'app:get-keyboard-shortcuts',
-    (): Result<Record<string, string>> => {
-      try {
-        const settings = readSettings();
-        return ok(settings.keyboard_shortcut_overrides ?? {});
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('app:get-keyboard-shortcuts', (): Result<Record<string, string>> => {
+    try {
+      const settings = readSettings();
+      return ok(settings.keyboard_shortcut_overrides ?? {});
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // SET 은 plain Record<string,string> 으로 검증. 빈 object 는 모든 override
   // 제거 = default 복원. action / combo 형식 검증은 renderer 가 책임 — main
   // 은 단순 영속 layer (corrupt-tolerant: 빈 키/값 drop, 그 외는 그대로 저장).
-  ipcMain.handle(
-    'app:set-keyboard-shortcuts',
-    (_evt, raw: unknown): Result<void> => {
-      try {
-        if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
-          throw new Error('keyboard_shortcut_overrides must be a plain object');
-        }
-        const obj = raw as Record<string, unknown>;
-        const validated: Record<string, string> = {};
-        for (const [k, v] of Object.entries(obj)) {
-          if (typeof k !== 'string' || k.length === 0) continue;
-          if (typeof v !== 'string' || v.length === 0) continue;
-          // 키 / 값 길이 상한 — 의도치 않은 거대 payload 차단.
-          if (k.length > 64) continue;
-          if (v.length > 64) continue;
-          validated[k] = v;
-        }
-        writeSettings({ keyboard_shortcut_overrides: validated });
-        return ok(undefined);
-      } catch (err) {
-        return fail(err);
+  ipcMain.handle('app:set-keyboard-shortcuts', (_evt, raw: unknown): Result<void> => {
+    try {
+      if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new Error('keyboard_shortcut_overrides must be a plain object');
       }
+      const obj = raw as Record<string, unknown>;
+      const validated: Record<string, string> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (typeof k !== 'string' || k.length === 0) continue;
+        if (typeof v !== 'string' || v.length === 0) continue;
+        // 키 / 값 길이 상한 — 의도치 않은 거대 payload 차단.
+        if (k.length > 64) continue;
+        if (v.length > 64) continue;
+        validated[k] = v;
+      }
+      writeSettings({ keyboard_shortcut_overrides: validated });
+      return ok(undefined);
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   ipcMain.handle('app:get-default-workspace', (): Result<WorkspaceInfo | null> => {
     try {
@@ -934,38 +908,32 @@ export function registerIpcHandlers(
   // 정보는 반환. DB 쪽 정보는 store 가 있을 때만 채움.
   // v1.7.15 — telemetry_enabled get/set. settings.json 에 영속 + 즉시
   // Telemetry singleton 의 setEnabled 반영.
-  ipcMain.handle(
-    'app:get-telemetry-enabled',
-    (): Result<boolean> => {
-      try {
-        return ok(readSettings().telemetry_enabled === true);
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('app:get-telemetry-enabled', (): Result<boolean> => {
+    try {
+      return ok(readSettings().telemetry_enabled === true);
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
-  ipcMain.handle(
-    'app:set-telemetry-enabled',
-    async (_evt, raw: unknown): Promise<Result<void>> => {
-      try {
-        if (typeof raw !== 'boolean') {
-          throw new Error('telemetry_enabled must be boolean');
-        }
-        writeSettings({ telemetry_enabled: raw });
-        // Telemetry singleton 도 즉시 반영 (다음 emit 부터 적용).
-        try {
-          const tel = (await import('./telemetry/Telemetry')).getTelemetry();
-          tel.setEnabled(raw);
-        } catch {
-          // singleton 미초기화 — 다음 부팅에서 settings 가 적용됨.
-        }
-        return ok(undefined);
-      } catch (err) {
-        return fail(err);
+  ipcMain.handle('app:set-telemetry-enabled', async (_evt, raw: unknown): Promise<Result<void>> => {
+    try {
+      if (typeof raw !== 'boolean') {
+        throw new Error('telemetry_enabled must be boolean');
       }
+      writeSettings({ telemetry_enabled: raw });
+      // Telemetry singleton 도 즉시 반영 (다음 emit 부터 적용).
+      try {
+        const tel = (await import('./telemetry/Telemetry')).getTelemetry();
+        tel.setEnabled(raw);
+      } catch {
+        // singleton 미초기화 — 다음 부팅에서 settings 가 적용됨.
+      }
+      return ok(undefined);
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // v1.4.0 follow-up — 사용자가 [DB 진단] 패널에서 trigger. workspace_id
   // FNV → sha256 backfill 을 명시 호출. 결과 통계 반환.
@@ -985,9 +953,7 @@ export function registerIpcHandlers(
         if (store === undefined) {
           throw new Error('SessionStore not initialized');
         }
-        const { backfillWorkspaceIdsToSha256 } = await import(
-          '../storage/workspaceBackfill'
-        );
+        const { backfillWorkspaceIdsToSha256 } = await import('../storage/workspaceBackfill');
         const r = backfillWorkspaceIdsToSha256(store.getDb());
         // v1.4.8 — 마이그레이션 완료 → flag set.
         try {
@@ -1031,9 +997,7 @@ export function registerIpcHandlers(
             flag_done: flagDone,
           });
         }
-        const { detectLegacyWorkspaceIds } = await import(
-          '../storage/workspaceBackfill'
-        );
+        const { detectLegacyWorkspaceIds } = await import('../storage/workspaceBackfill');
         const r = detectLegacyWorkspaceIds(store.getDb());
         return ok({
           total: r.total,
@@ -1048,17 +1012,14 @@ export function registerIpcHandlers(
   );
 
   // v1.4.8 — Dismiss. modal 의 [다시 묻지 않기] — backfill 미실행 + flag 만 set.
-  ipcMain.handle(
-    'app:dismiss-workspace-backfill',
-    (): Result<void> => {
-      try {
-        writeSettings({ workspace_backfill_done: true });
-        return ok(undefined);
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('app:dismiss-workspace-backfill', (): Result<void> => {
+    try {
+      writeSettings({ workspace_backfill_done: true });
+      return ok(undefined);
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // v1.4.11 — Conflict listing. 충돌 row 들의 detail (root + session_count)
   // 을 사용자에게 노출 — modal 에서 row 별 처리 가능.
@@ -1076,9 +1037,7 @@ export function registerIpcHandlers(
     > => {
       try {
         if (store === undefined) return ok([]);
-        const { listBackfillConflicts } = await import(
-          '../storage/workspaceBackfill'
-        );
+        const { listBackfillConflicts } = await import('../storage/workspaceBackfill');
         return ok(listBackfillConflicts(store.getDb()));
       } catch (err) {
         return fail(err);
@@ -1100,9 +1059,7 @@ export function registerIpcHandlers(
           return fail('legacy_id required');
         }
         if (store === undefined) return fail('store not loaded');
-        const { deleteLegacyWorkspace } = await import(
-          '../storage/workspaceBackfill'
-        );
+        const { deleteLegacyWorkspace } = await import('../storage/workspaceBackfill');
         return ok(deleteLegacyWorkspace(store.getDb(), legacyId));
       } catch (err) {
         return fail(err);
@@ -1328,125 +1285,113 @@ function registerAutomationHandlers(audit?: AuditLogStore): void {
     });
   }
 
-  ipcMain.handle(
-    'automation/list',
-    (): Result<AutomationRuleSummary[]> => {
-      try {
-        const mgr = getAutomationManager();
-        return ok(mgr.list().map((r) => summarizeRule(r)));
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('automation/list', (): Result<AutomationRuleSummary[]> => {
+    try {
+      const mgr = getAutomationManager();
+      return ok(mgr.list().map((r) => summarizeRule(r)));
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
-  ipcMain.handle(
-    'automation/register',
-    (_evt, raw: unknown): Result<AutomationRuleSummary> => {
-      try {
-        if (raw === null || typeof raw !== 'object') {
-          throw new Error('rule must be an object');
-        }
-        const obj = raw as Record<string, unknown>;
-        const name = String(obj['name'] ?? '');
-        const kind = obj['kind'];
-        if (kind !== 'interval' && kind !== 'cron' && kind !== 'webhook') {
-          throw new Error("kind must be 'interval' | 'cron' | 'webhook'");
-        }
-        if (name.length === 0 || name.length > 64) {
-          throw new Error('name must be 1..64 chars');
-        }
+  ipcMain.handle('automation/register', (_evt, raw: unknown): Result<AutomationRuleSummary> => {
+    try {
+      if (raw === null || typeof raw !== 'object') {
+        throw new Error('rule must be an object');
+      }
+      const obj = raw as Record<string, unknown>;
+      const name = String(obj['name'] ?? '');
+      const kind = obj['kind'];
+      if (kind !== 'interval' && kind !== 'cron' && kind !== 'webhook') {
+        throw new Error("kind must be 'interval' | 'cron' | 'webhook'");
+      }
+      if (name.length === 0 || name.length > 64) {
+        throw new Error('name must be 1..64 chars');
+      }
 
-        // v1.7.23 — handler registry lookup. handler_name 미지정 시 noop-log
-        // (종전 동작 호환). 알려지지 않은 이름은 immediate fail — 사용자가
-        // typo 한 경우 silent fall-back 보다 fail-fast 가 안전.
-        registerBuiltinHandlers();
-        const handlerName =
-          typeof obj['handler_name'] === 'string' && obj['handler_name'].length > 0
-            ? obj['handler_name']
-            : NOOP_LOG_HANDLER_NAME;
-        const handlerConfig =
-          obj['handler_config'] !== null &&
-          typeof obj['handler_config'] === 'object' &&
-          !Array.isArray(obj['handler_config'])
-            ? (obj['handler_config'] as Record<string, unknown>)
-            : {};
-        const handlerFn = handlerRegistry.get(handlerName);
-        if (handlerFn === undefined) {
-          throw new Error(`unknown handler_name: ${handlerName}`);
-        }
+      // v1.7.23 — handler registry lookup. handler_name 미지정 시 noop-log
+      // (종전 동작 호환). 알려지지 않은 이름은 immediate fail — 사용자가
+      // typo 한 경우 silent fall-back 보다 fail-fast 가 안전.
+      registerBuiltinHandlers();
+      const handlerName =
+        typeof obj['handler_name'] === 'string' && obj['handler_name'].length > 0
+          ? obj['handler_name']
+          : NOOP_LOG_HANDLER_NAME;
+      const handlerConfig =
+        obj['handler_config'] !== null &&
+        typeof obj['handler_config'] === 'object' &&
+        !Array.isArray(obj['handler_config'])
+          ? (obj['handler_config'] as Record<string, unknown>)
+          : {};
+      const handlerFn = handlerRegistry.get(handlerName);
+      if (handlerFn === undefined) {
+        throw new Error(`unknown handler_name: ${handlerName}`);
+      }
 
-        const mgr = getAutomationManager();
-        const handler = async (): Promise<unknown> =>
-          handlerFn({ rule_name: name, config: handlerConfig });
+      const mgr = getAutomationManager();
+      const handler = async (): Promise<unknown> =>
+        handlerFn({ rule_name: name, config: handlerConfig });
 
-        mgr.register({
-          name,
-          kind,
-          ...(typeof obj['interval_ms'] === 'number' && {
-            interval_ms: obj['interval_ms'],
-          }),
-          ...(typeof obj['cron_expr'] === 'string' && {
-            cron_expr: obj['cron_expr'],
-          }),
-          ...(typeof obj['cron_tz'] === 'string' && {
-            cron_tz: obj['cron_tz'],
-          }),
-          ...(typeof obj['webhook_path'] === 'string' && {
-            webhook_path: obj['webhook_path'],
-          }),
-          handler_name: handlerName,
-          handler_config: handlerConfig,
-          handler,
-        });
-        const registered = mgr.list().find((r) => r.name === name);
-        if (registered === undefined) {
-          throw new Error('register failed (rule not found after insert)');
-        }
-        // v1.7.14 — settings 에 write-through 영속.
+      mgr.register({
+        name,
+        kind,
+        ...(typeof obj['interval_ms'] === 'number' && {
+          interval_ms: obj['interval_ms'],
+        }),
+        ...(typeof obj['cron_expr'] === 'string' && {
+          cron_expr: obj['cron_expr'],
+        }),
+        ...(typeof obj['cron_tz'] === 'string' && {
+          cron_tz: obj['cron_tz'],
+        }),
+        ...(typeof obj['webhook_path'] === 'string' && {
+          webhook_path: obj['webhook_path'],
+        }),
+        handler_name: handlerName,
+        handler_config: handlerConfig,
+        handler,
+      });
+      const registered = mgr.list().find((r) => r.name === name);
+      if (registered === undefined) {
+        throw new Error('register failed (rule not found after insert)');
+      }
+      // v1.7.14 — settings 에 write-through 영속.
+      persistAutomationRules(mgr.list().map((rl) => summarizeRule(rl)));
+      return ok(summarizeRule(registered));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+
+  ipcMain.handle('automation/unregister', (_evt, raw: unknown): Result<{ removed: boolean }> => {
+    try {
+      if (typeof raw !== 'string' || raw.length === 0) {
+        throw new Error('rule name must be a non-empty string');
+      }
+      const mgr = getAutomationManager();
+      const removed = mgr.unregister(raw);
+      // v1.7.14 — write-through.
+      if (removed) {
         persistAutomationRules(mgr.list().map((rl) => summarizeRule(rl)));
-        return ok(summarizeRule(registered));
-      } catch (err) {
-        return fail(err);
       }
+      return ok({ removed });
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
-  ipcMain.handle(
-    'automation/unregister',
-    (_evt, raw: unknown): Result<{ removed: boolean }> => {
-      try {
-        if (typeof raw !== 'string' || raw.length === 0) {
-          throw new Error('rule name must be a non-empty string');
-        }
-        const mgr = getAutomationManager();
-        const removed = mgr.unregister(raw);
-        // v1.7.14 — write-through.
-        if (removed) {
-          persistAutomationRules(mgr.list().map((rl) => summarizeRule(rl)));
-        }
-        return ok({ removed });
-      } catch (err) {
-        return fail(err);
+  ipcMain.handle('automation/fire', async (_evt, raw: unknown): Promise<Result<void>> => {
+    try {
+      if (typeof raw !== 'string' || raw.length === 0) {
+        throw new Error('rule name must be a non-empty string');
       }
+      const mgr = getAutomationManager();
+      await mgr.fire(raw);
+      return ok(undefined);
+    } catch (err) {
+      return fail(err);
     }
-  );
-
-  ipcMain.handle(
-    'automation/fire',
-    async (_evt, raw: unknown): Promise<Result<void>> => {
-      try {
-        if (typeof raw !== 'string' || raw.length === 0) {
-          throw new Error('rule name must be a non-empty string');
-        }
-        const mgr = getAutomationManager();
-        await mgr.fire(raw);
-        return ok(undefined);
-      } catch (err) {
-        return fail(err);
-      }
-    }
-  );
+  });
 
   ipcMain.handle(
     'automation/get-next-run',
@@ -1464,17 +1409,14 @@ function registerAutomationHandlers(audit?: AuditLogStore): void {
   );
 
   // v1.7.23 — Registered handler 이름 목록. UI dropdown 의 source.
-  ipcMain.handle(
-    'automation/list-handlers',
-    (): Result<string[]> => {
-      try {
-        registerBuiltinHandlers();
-        return ok(handlerRegistry.list());
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('automation/list-handlers', (): Result<string[]> => {
+    try {
+      registerBuiltinHandlers();
+      return ok(handlerRegistry.list());
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // v1.7.27 — rule enabled/disabled toggle.
   ipcMain.handle('automation/set-enabled', (_evt, args: unknown): Result<boolean> => {
@@ -1508,10 +1450,7 @@ function registerAutomationHandlers(audit?: AuditLogStore): void {
   // 에 모아 부분 성공도 보고. 보안: caller (renderer) 가 user confirm 후 호출.
   ipcMain.handle(
     'automation/import',
-    (
-      _evt,
-      args: unknown
-    ): Result<{ added: number; skipped: number; errors: string[] }> => {
+    (_evt, args: unknown): Result<{ added: number; skipped: number; errors: string[] }> => {
       try {
         if (args === null || typeof args !== 'object') return fail('args required');
         const { json, mode } = args as { json?: unknown; mode?: unknown };
@@ -1522,7 +1461,9 @@ function registerAutomationHandlers(audit?: AuditLogStore): void {
         const result = importAutomationRulesJson(getAutomationManager(), json, overwrite);
         if (!result.ok) return fail(result.error);
         persistAutomationRules(
-          getAutomationManager().list().map((rl) => summarizeRule(rl))
+          getAutomationManager()
+            .list()
+            .map((rl) => summarizeRule(rl))
         );
         return ok(result.value);
       } catch (err) {
@@ -1570,34 +1511,23 @@ export interface PermissionHandlerConfig {
   confirmer: import('./IpcPermissionConfirmer').IpcPermissionConfirmer;
 }
 
-function registerPermissionHandlers(
-  cfg: PermissionHandlerConfig,
-  store?: SessionStore
-): void {
-  ipcMain.handle(
-    'permission/respond',
-    (event, raw: unknown): Result<{ matched: boolean }> => {
-      try {
-        const args = PermissionRespondArgsSchema.parse(raw);
-        // v1.1.3 hotfix (Codex Q9): event.sender.id 를 confirmer 에 전달.
-        // confirm 시점 owner webContents 와 다르면 silently drop — 다른 창
-        // 또는 spoofed sender 차단.
-        const senderId =
-          typeof (event as { sender?: { id?: unknown } } | undefined)?.sender?.id === 'number'
-            ? (event as { sender: { id: number } }).sender.id
-            : undefined;
-        const matched = cfg.confirmer.respond(
-          args.request_id,
-          args.decision,
-          args.reason,
-          senderId
-        );
-        return ok({ matched });
-      } catch (err) {
-        return fail(err);
-      }
+function registerPermissionHandlers(cfg: PermissionHandlerConfig, store?: SessionStore): void {
+  ipcMain.handle('permission/respond', (event, raw: unknown): Result<{ matched: boolean }> => {
+    try {
+      const args = PermissionRespondArgsSchema.parse(raw);
+      // v1.1.3 hotfix (Codex Q9): event.sender.id 를 confirmer 에 전달.
+      // confirm 시점 owner webContents 와 다르면 silently drop — 다른 창
+      // 또는 spoofed sender 차단.
+      const senderId =
+        typeof (event as { sender?: { id?: unknown } } | undefined)?.sender?.id === 'number'
+          ? (event as { sender: { id: number } }).sender.id
+          : undefined;
+      const matched = cfg.confirmer.respond(args.request_id, args.decision, args.reason, senderId);
+      return ok({ matched });
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   ipcMain.handle('permission/list-pending', (event): Result<unknown[]> => {
     try {
@@ -1616,30 +1546,22 @@ function registerPermissionHandlers(
     try {
       const args = PermissionGrantsListArgsSchema.parse(raw);
       if (store === undefined) return ok([]);
-      return ok(
-        store.listActivePermissionGrants(args.session_id as import('@/types').SessionId)
-      );
+      return ok(store.listActivePermissionGrants(args.session_id as import('@/types').SessionId));
     } catch (err) {
       return fail(err);
     }
   });
 
-  ipcMain.handle(
-    'permission/grants/revoke',
-    (_evt, raw: unknown): Result<{ revoked: boolean }> => {
-      try {
-        const args = PermissionGrantsRevokeArgsSchema.parse(raw);
-        if (store === undefined) return ok({ revoked: false });
-        const revoked = store.revokePermissionGrant(
-          args.grant_id,
-          new Date().toISOString()
-        );
-        return ok({ revoked });
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('permission/grants/revoke', (_evt, raw: unknown): Result<{ revoked: boolean }> => {
+    try {
+      const args = PermissionGrantsRevokeArgsSchema.parse(raw);
+      if (store === undefined) return ok({ revoked: false });
+      const revoked = store.revokePermissionGrant(args.grant_id, new Date().toISOString());
+      return ok({ revoked });
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 }
 
 // ────────────────────────────────────────────────────────────
@@ -1649,9 +1571,7 @@ function registerPermissionHandlers(
 function registerWorkspaceHandlers(electronApp: App): void {
   ipcMain.handle(
     'workspace/pick-folder',
-    async (
-      event: IpcMainInvokeEvent
-    ): Promise<Result<{ path: string; name: string } | null>> => {
+    async (event: IpcMainInvokeEvent): Promise<Result<{ path: string; name: string } | null>> => {
       try {
         // v1.0.4 fix — parent BrowserWindow 명시. 이전엔 옵션만 넘겨서
         // Windows 에서 dialog 가 main window 뒤로 가거나 안 뜨는 증상이 있었음
@@ -1712,10 +1632,7 @@ function registerWorkspaceHandlers(electronApp: App): void {
         // v1.0.14 (META-4 hotfix): 저장된 workspace 가 userData 와 충돌하면
         // null 반환 — 사용자가 picker 로 다시 선택해야 함.
         const userDataDir = electronApp.getPath('userData');
-        const conflict = checkUserDataConflict(
-          settings.workspace_root,
-          userDataDir
-        );
+        const conflict = checkUserDataConflict(settings.workspace_root, userDataDir);
         if (conflict !== null) {
           console.warn('[workspace/get] saved workspace conflicts with userData:', conflict);
           return ok(null);
@@ -1736,62 +1653,65 @@ function registerWorkspaceHandlers(electronApp: App): void {
   //   prune 해서 node_modules 같은 거대한 트리에 진입 X)
   // - max_files 도달 시 즉시 중단, 부분 결과 반환
   // - 심볼릭 / 권한 오류는 silently skip — 한 손상 항목이 전체 enumerate 를 깨뜨리지 않도록
-  ipcMain.handle('workspace/list-files', async (_evt, raw: unknown): Promise<Result<FileEntry[]>> => {
-    try {
-      const args = ListFilesArgsSchema.parse(raw);
-      const root = path.resolve(args.workspace_root);
-      const stat = await fsp.stat(root).catch(() => null);
-      if (stat === null || !stat.isDirectory()) {
-        throw new Error('workspace_root must be an existing directory');
-      }
-      const cap = args.max_files ?? FILE_LIST_DEFAULT_MAX_FILES;
-      const compiled = (args.ignore_patterns ?? []).map(compileGlob);
-      const out: FileEntry[] = [];
-      // BFS 가 아닌 DFS — 결과 순서는 caller 가 sort 한다.
-      const stack: Array<{ abs: string; rel: string; depth: number }> = [
-        { abs: root, rel: '', depth: 0 },
-      ];
-      while (stack.length > 0) {
-        if (out.length >= cap) break;
-        const top = stack.pop();
-        if (top === undefined) break;
-        if (top.depth > FILE_LIST_MAX_DEPTH) continue;
-        let entries: import('node:fs').Dirent[] = [];
-        try {
-          entries = await fsp.readdir(top.abs, { withFileTypes: true });
-        } catch {
-          // 권한 / 손상 디렉토리는 skip — silent
-          continue;
+  ipcMain.handle(
+    'workspace/list-files',
+    async (_evt, raw: unknown): Promise<Result<FileEntry[]>> => {
+      try {
+        const args = ListFilesArgsSchema.parse(raw);
+        const root = path.resolve(args.workspace_root);
+        const stat = await fsp.stat(root).catch(() => null);
+        if (stat === null || !stat.isDirectory()) {
+          throw new Error('workspace_root must be an existing directory');
         }
-        for (const ent of entries) {
+        const cap = args.max_files ?? FILE_LIST_DEFAULT_MAX_FILES;
+        const compiled = (args.ignore_patterns ?? []).map(compileGlob);
+        const out: FileEntry[] = [];
+        // BFS 가 아닌 DFS — 결과 순서는 caller 가 sort 한다.
+        const stack: Array<{ abs: string; rel: string; depth: number }> = [
+          { abs: root, rel: '', depth: 0 },
+        ];
+        while (stack.length > 0) {
           if (out.length >= cap) break;
-          const childRel = top.rel.length === 0 ? ent.name : `${top.rel}/${ent.name}`;
-          // POSIX-style relative path 로 정규화
-          const relForMatch = childRel.split(path.sep).join('/');
-          if (isIgnored(relForMatch, compiled)) continue;
-          const childAbs = path.join(top.abs, ent.name);
-          if (ent.isDirectory()) {
-            stack.push({ abs: childAbs, rel: relForMatch, depth: top.depth + 1 });
+          const top = stack.pop();
+          if (top === undefined) break;
+          if (top.depth > FILE_LIST_MAX_DEPTH) continue;
+          let entries: import('node:fs').Dirent[] = [];
+          try {
+            entries = await fsp.readdir(top.abs, { withFileTypes: true });
+          } catch {
+            // 권한 / 손상 디렉토리는 skip — silent
             continue;
           }
-          if (!ent.isFile()) continue; // symlink / device 등은 skip
-          let size_bytes = 0;
-          let mtime = '';
-          try {
-            const fileStat = await fsp.stat(childAbs);
-            size_bytes = fileStat.size;
-            mtime = fileStat.mtime.toISOString();
-          } catch {
-            continue; // stat 실패 → skip
+          for (const ent of entries) {
+            if (out.length >= cap) break;
+            const childRel = top.rel.length === 0 ? ent.name : `${top.rel}/${ent.name}`;
+            // POSIX-style relative path 로 정규화
+            const relForMatch = childRel.split(path.sep).join('/');
+            if (isIgnored(relForMatch, compiled)) continue;
+            const childAbs = path.join(top.abs, ent.name);
+            if (ent.isDirectory()) {
+              stack.push({ abs: childAbs, rel: relForMatch, depth: top.depth + 1 });
+              continue;
+            }
+            if (!ent.isFile()) continue; // symlink / device 등은 skip
+            let size_bytes = 0;
+            let mtime = '';
+            try {
+              const fileStat = await fsp.stat(childAbs);
+              size_bytes = fileStat.size;
+              mtime = fileStat.mtime.toISOString();
+            } catch {
+              continue; // stat 실패 → skip
+            }
+            out.push({ path: relForMatch, size_bytes, mtime });
           }
-          out.push({ path: relForMatch, size_bytes, mtime });
         }
+        return ok(out);
+      } catch (err) {
+        return fail(err);
       }
-      return ok(out);
-    } catch (err) {
-      return fail(err);
     }
-  });
+  );
 
   // ── workspace/read-file (v0.6.0 — F-019 @ 멘션) ─────────────────────
   // 입력: { workspace_root, rel_path, max_bytes? }
@@ -1800,43 +1720,44 @@ function registerWorkspaceHandlers(electronApp: App): void {
   //   - path traversal 거절 (resolveInsideWorkspace)
   //   - 디렉토리 / 1MB 초과 / binary 파일 거절
   //   - max_bytes 까지만 읽고 truncated=true 표시
-  ipcMain.handle('workspace/read-file', async (_evt, raw: unknown): Promise<Result<FileContent>> => {
-    try {
-      const args = ReadFileArgsSchema.parse(raw);
-      const abs = await resolveInsideWorkspace(args.workspace_root, args.rel_path);
-      const stat = await fsp.stat(abs).catch(() => null);
-      if (stat === null) {
-        throw new Error('file not found');
+  ipcMain.handle(
+    'workspace/read-file',
+    async (_evt, raw: unknown): Promise<Result<FileContent>> => {
+      try {
+        const args = ReadFileArgsSchema.parse(raw);
+        const abs = await resolveInsideWorkspace(args.workspace_root, args.rel_path);
+        const stat = await fsp.stat(abs).catch(() => null);
+        if (stat === null) {
+          throw new Error('file not found');
+        }
+        if (stat.isDirectory()) {
+          throw new Error('path is a directory, not a file');
+        }
+        if (stat.size > FILE_READ_HARD_MAX_BYTES) {
+          throw new Error(`file too large: ${stat.size} bytes (max ${FILE_READ_HARD_MAX_BYTES})`);
+        }
+        const limit = args.max_bytes ?? FILE_READ_DEFAULT_MAX_BYTES;
+        const buf = await fsp.readFile(abs);
+        if (looksBinary(buf)) {
+          throw new Error('binary file rejected');
+        }
+        const truncated = buf.length > limit;
+        const slice = truncated ? buf.subarray(0, limit) : buf;
+        const content = slice.toString('utf8');
+        // line_count = '\n' 개수 + 1 (빈 파일은 1줄로 간주). truncated 인 경우
+        // 실제 파일은 더 많은 줄을 포함할 수 있지만 caller 에 표시되는 snippet
+        // 기준 라인 수가 더 유용하다.
+        let nl = 0;
+        for (let i = 0; i < content.length; i++) {
+          if (content.charCodeAt(i) === 10) nl++;
+        }
+        const line_count = nl + 1;
+        return ok({ content, truncated, line_count });
+      } catch (err) {
+        return fail(err);
       }
-      if (stat.isDirectory()) {
-        throw new Error('path is a directory, not a file');
-      }
-      if (stat.size > FILE_READ_HARD_MAX_BYTES) {
-        throw new Error(
-          `file too large: ${stat.size} bytes (max ${FILE_READ_HARD_MAX_BYTES})`
-        );
-      }
-      const limit = args.max_bytes ?? FILE_READ_DEFAULT_MAX_BYTES;
-      const buf = await fsp.readFile(abs);
-      if (looksBinary(buf)) {
-        throw new Error('binary file rejected');
-      }
-      const truncated = buf.length > limit;
-      const slice = truncated ? buf.subarray(0, limit) : buf;
-      const content = slice.toString('utf8');
-      // line_count = '\n' 개수 + 1 (빈 파일은 1줄로 간주). truncated 인 경우
-      // 실제 파일은 더 많은 줄을 포함할 수 있지만 caller 에 표시되는 snippet
-      // 기준 라인 수가 더 유용하다.
-      let nl = 0;
-      for (let i = 0; i < content.length; i++) {
-        if (content.charCodeAt(i) === 10) nl++;
-      }
-      const line_count = nl + 1;
-      return ok({ content, truncated, line_count });
-    } catch (err) {
-      return fail(err);
     }
-  });
+  );
 }
 
 // ────────────────────────────────────────────────────────────
@@ -1943,30 +1864,24 @@ function registerSessionHandlers(store: SessionStore): void {
 
   // v1.1.11 (Workspace UX): per-session sticky workspace lock toggle.
   // ChatHeader 의 🔒 toggle 이 호출. payload: { sessionId, locked }.
-  ipcMain.handle(
-    'session/set-workspace-locked',
-    (_evt, raw: unknown): Result<{ ok: boolean }> => {
-      try {
-        if (typeof raw !== 'object' || raw === null) {
-          throw new Error('payload must be object { sessionId, locked }');
-        }
-        const obj = raw as { sessionId?: unknown; locked?: unknown };
-        if (typeof obj.sessionId !== 'string' || obj.sessionId.length === 0) {
-          throw new Error('sessionId required');
-        }
-        if (typeof obj.locked !== 'boolean') {
-          throw new Error('locked must be boolean');
-        }
-        const updated = store.setWorkspaceLocked(
-          obj.sessionId as SessionId,
-          obj.locked
-        );
-        return ok({ ok: updated });
-      } catch (err) {
-        return fail(err);
+  ipcMain.handle('session/set-workspace-locked', (_evt, raw: unknown): Result<{ ok: boolean }> => {
+    try {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new Error('payload must be object { sessionId, locked }');
       }
+      const obj = raw as { sessionId?: unknown; locked?: unknown };
+      if (typeof obj.sessionId !== 'string' || obj.sessionId.length === 0) {
+        throw new Error('sessionId required');
+      }
+      if (typeof obj.locked !== 'boolean') {
+        throw new Error('locked must be boolean');
+      }
+      const updated = store.setWorkspaceLocked(obj.sessionId as SessionId, obj.locked);
+      return ok({ ok: updated });
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // v1.1.11: 특정 세션의 lock 상태 read — UI 가 mount 시 동기화.
   ipcMain.handle(
@@ -2036,17 +1951,14 @@ function registerSessionHandlers(store: SessionStore): void {
   // v0.7.0 (F-026) — Sidebar 검색 입력 → BM25 ranked turn matches across all
   // sessions. Renderer 는 결과를 클릭해 해당 turn 으로 scroll.
   // q 는 trim+1자 이상, 200자 미만, limit 은 100 미만 으로 Zod 가 강제.
-  ipcMain.handle(
-    'session/search',
-    (_evt, raw: unknown): Result<TurnSearchResult[]> => {
-      try {
-        const { q, limit } = SearchTurnsArgsSchema.parse(raw);
-        return ok(store.searchTurns(q, limit ?? 50));
-      } catch (err) {
-        return fail(err);
-      }
+  ipcMain.handle('session/search', (_evt, raw: unknown): Result<TurnSearchResult[]> => {
+    try {
+      const { q, limit } = SearchTurnsArgsSchema.parse(raw);
+      return ok(store.searchTurns(q, limit ?? 50));
+    } catch (err) {
+      return fail(err);
     }
-  );
+  });
 
   // v0.8.0 — H Permission Dropdown — 세션의 default_level 변경. metadata-only
   // change. 갱신된 Session 을 반환해 caller (renderer) 가 즉시 local state 에
@@ -2281,11 +2193,16 @@ function registerBrowserHandlers(browser: BrowserManager): void {
   // 로 직렬화해 renderer 에 반환. 파일 저장은 renderer / 후속 슬롯에서.
   ipcMain.handle(
     'browser/capture-tab',
-    async (_evt, tabId: unknown): Promise<Result<{
-      png_base64: string;
-      width: number;
-      height: number;
-    } | null>> => {
+    async (
+      _evt,
+      tabId: unknown
+    ): Promise<
+      Result<{
+        png_base64: string;
+        width: number;
+        height: number;
+      } | null>
+    > => {
       try {
         if (typeof tabId !== 'string') {
           throw new Error('tab id must be string');
@@ -2400,9 +2317,7 @@ function registerToolHandlers(tools: ToolHandlerConfig): void {
       // v1.1.2 hotfix (Codex Q8): event.sender.id 를 webContentsId 로 전달.
       // Electron 이 보장하는 신뢰 가능 출처 — renderer 가 spoof 불가. Queue
       // 의 sessionGrants 가 본 ID 버킷에 격리됨.
-      return ok(
-        await tools.queue.enqueue(call, { web_contents_id: event.sender.id })
-      );
+      return ok(await tools.queue.enqueue(call, { web_contents_id: event.sender.id }));
     } catch (err) {
       return fail(err);
     }
@@ -2643,9 +2558,7 @@ function registerUsageHandlers(usageStore: UsageStore): void {
           cost_limit_usd: settings.usage_cost_limit_usd,
         }),
         alert_threshold:
-          typeof settings.usage_alert_threshold === 'number'
-            ? settings.usage_alert_threshold
-            : 0.8,
+          typeof settings.usage_alert_threshold === 'number' ? settings.usage_alert_threshold : 0.8,
       });
     } catch (err) {
       return fail(err);
@@ -2824,7 +2737,7 @@ function registerAiHandlers(cfg: AiHandlerConfig, usage?: UsageStore): void {
         // 테스트 stub 의 evt.sender 가 number 가 아니어도 안전한 fallback.
         const senderId =
           typeof (event as { sender?: { id?: unknown } } | undefined)?.sender?.id === 'number'
-            ? ((event as { sender: { id: number } }).sender.id)
+            ? (event as { sender: { id: number } }).sender.id
             : 0;
         const { stream_id, model, turns, session_id, workspace_root, permission_level } =
           StartStreamArgsSchema.parse(args);
@@ -2914,8 +2827,7 @@ function registerAiHandlers(cfg: AiHandlerConfig, usage?: UsageStore): void {
         // v0.3.0 — settings.default_provider 를 매 stream 마다 fresh 로 읽음.
         // 사용자가 wizard 또는 설정에서 변경하면 즉시 반영. 'auto' 는 종전 동작.
         const settings = readSettings();
-        const userDefaultProvider: DefaultProviderChoice =
-          settings.default_provider ?? 'auto';
+        const userDefaultProvider: DefaultProviderChoice = settings.default_provider ?? 'auto';
         const controller = new AbortController();
         const { provider, source } = await getDefaultProviderFn(
           model,
@@ -2995,10 +2907,7 @@ async function runStreamPump(
   // v1.6.5 — Plugin Hook integration. pre_turn 호출 (best-effort, throw 무시).
   // 본 시점은 실제 provider stream 시작 직전 — plugin 이 ctx.payload 를
   // 통해 turn 의 model/session 정보 확인 가능.
-  if (
-    cfg.pluginManager !== undefined &&
-    cfg.pluginHookRunner !== undefined
-  ) {
+  if (cfg.pluginManager !== undefined && cfg.pluginHookRunner !== undefined) {
     const plugins = cfg.pluginManager.list().loaded;
     if (plugins.length > 0) {
       try {
@@ -3097,10 +3006,7 @@ async function runStreamPump(
 
     // v1.6.5/v1.6.6 — Plugin post_turn hook (best-effort). cost-limit-hook
     // 이 본 ctx.payload.mtd_total_usd / limit_usd 검사 → 한도 초과 시 toast.
-    if (
-      cfg.pluginManager !== undefined &&
-      cfg.pluginHookRunner !== undefined
-    ) {
+    if (cfg.pluginManager !== undefined && cfg.pluginHookRunner !== undefined) {
       const plugins = cfg.pluginManager.list().loaded;
       if (plugins.length > 0) {
         const payload: Record<string, unknown> = {

--- a/src/main/mcp/McpManager.ts
+++ b/src/main/mcp/McpManager.ts
@@ -75,10 +75,7 @@ export class McpManager {
   private readonly clients = new Map<string, McpClient>();
   private readonly settings: McpManagerSettingsAdapter;
   private readonly clientOptions: McpClientOptions | undefined;
-  private readonly createClient: (
-    config: McpServerConfig,
-    options?: McpClientOptions
-  ) => McpClient;
+  private readonly createClient: (config: McpServerConfig, options?: McpClientOptions) => McpClient;
   /** v1.0.13 (FAKE-5): schema 변환 audit sink. 미설정 시 dormant. */
   private readonly options: McpManagerOptions;
 
@@ -89,8 +86,7 @@ export class McpManager {
     this.options = options;
     this.settings = options.settings;
     this.clientOptions = options.clientOptions;
-    this.createClient =
-      options.createClient ?? ((config, opts) => new McpClient(config, opts));
+    this.createClient = options.createClient ?? ((config, opts) => new McpClient(config, opts));
   }
 
   // ──────────────────────────────────────────────────────────
@@ -226,7 +222,8 @@ export class McpManager {
       const client = this.clients.get(config.id);
       const state: McpServerState = {
         config,
-        status: client !== undefined ? client.getStatus() : config.enabled ? 'disconnected' : 'disabled',
+        status:
+          client !== undefined ? client.getStatus() : config.enabled ? 'disconnected' : 'disabled',
         tools: client !== undefined ? client.getTools() : [],
         last_log: client !== undefined ? client.getLogTail() : [],
       };
@@ -246,11 +243,7 @@ export class McpManager {
   // 내부 — Tool wrapper / registry sync
   // ──────────────────────────────────────────────────────────
 
-  private buildToolWrapper(
-    client: McpClient,
-    config: McpServerConfig,
-    info: McpToolInfo
-  ): Tool {
+  private buildToolWrapper(client: McpClient, config: McpServerConfig, info: McpToolInfo): Tool {
     const toolId = `mcp.${config.id}.${info.name}`;
     // v1.0.13 (FAKE-5): JSON Schema → Zod 중간 변환 (top-level type + required).
     // Codex 권고 (옵션 b). 변환 실패 / partial fallback 시 schemaAuditSink 호출.

--- a/src/main/mcp/discovery.ts
+++ b/src/main/mcp/discovery.ts
@@ -95,10 +95,7 @@ function claudeConfigCandidates(): string[] {
  */
 function codexConfigCandidates(): string[] {
   const home = homedir();
-  return [
-    join(home, '.codex', 'config.json'),
-    join(home, '.config', 'codex', 'config.json'),
-  ];
+  return [join(home, '.codex', 'config.json'), join(home, '.config', 'codex', 'config.json')];
 }
 
 /**

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -5,11 +5,7 @@
  */
 
 export { McpClient, type McpClientOptions, type SpawnFn } from './McpClient';
-export {
-  McpManager,
-  type McpManagerOptions,
-  type McpManagerSettingsAdapter,
-} from './McpManager';
+export { McpManager, type McpManagerOptions, type McpManagerSettingsAdapter } from './McpManager';
 export { createSettingsAdapter } from './settingsAdapter';
 export {
   SUGGESTED_MCP_SERVERS,

--- a/src/main/mcp/jsonSchemaToZod.ts
+++ b/src/main/mcp/jsonSchemaToZod.ts
@@ -71,9 +71,7 @@ export function jsonSchemaToZod(input: unknown): JsonSchemaToZodResult {
   const propsObj = propsRaw as JsonSchemaLike;
   const propKeys = Object.keys(propsObj);
   if (propKeys.length > MAX_PROPERTY_COUNT) {
-    warnings.push(
-      `properties count ${propKeys.length} > ${MAX_PROPERTY_COUNT} — truncating`
-    );
+    warnings.push(`properties count ${propKeys.length} > ${MAX_PROPERTY_COUNT} — truncating`);
   }
 
   const requiredSet = new Set<string>();
@@ -94,8 +92,7 @@ export function jsonSchemaToZod(input: unknown): JsonSchemaToZodResult {
   // additionalProperties: false 명시 시 strict, 그 외엔 passthrough (MCP 가
   // 추가 필드 보낼 수 있으니 관대).
   const additional = schemaObj['additionalProperties'];
-  const objSchema =
-    additional === false ? z.object(shape).strict() : z.object(shape).passthrough();
+  const objSchema = additional === false ? z.object(shape).strict() : z.object(shape).passthrough();
 
   return { schema: objSchema, converted: true, warnings };
 }
@@ -104,11 +101,7 @@ export function jsonSchemaToZod(input: unknown): JsonSchemaToZodResult {
  * Top-level type 만 변환 — string/number/boolean → 정확. object/array 는
  * z.unknown() (nested 는 P1 에서 변환). enum/format 등 은 미지원 (warnings).
  */
-function primitiveType(
-  prop: unknown,
-  warnings: string[],
-  key: string
-): z.ZodTypeAny {
+function primitiveType(prop: unknown, warnings: string[], key: string): z.ZodTypeAny {
   if (prop === null || prop === undefined || typeof prop !== 'object') {
     warnings.push(`property "${key}": malformed`);
     return z.unknown();

--- a/src/main/media/MediaStore.ts
+++ b/src/main/media/MediaStore.ts
@@ -11,15 +11,8 @@
  *  - meta sidecar `<sha256>.meta.json` — 원본 파일명 + mime + 추가시각.
  */
 
-import {
-  createHash,
-} from 'node:crypto';
-import {
-  mkdirSync,
-  promises as fsp,
-  readdirSync,
-  statSync,
-} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, promises as fsp, readdirSync, statSync } from 'node:fs';
 import { extname, join } from 'node:path';
 import { homedir } from 'node:os';
 

--- a/src/main/plugins/PluginCapabilityGate.ts
+++ b/src/main/plugins/PluginCapabilityGate.ts
@@ -13,21 +13,10 @@
  *    'session' 은 영속 X (의도된 한정 grant).
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type {
-  PermissionConfirmer,
-  PermissionGrantDuration,
-  PermissionRequest,
-} from '../../tools';
+import type { PermissionConfirmer, PermissionGrantDuration, PermissionRequest } from '../../tools';
 
 export interface PluginCapabilityAuditEvent {
   timestamp: string;
@@ -77,9 +66,7 @@ export class PluginCapabilityGate {
       options.auditSink ??
       ((e): void => {
         if (e.event !== 'plugin.cap_granted') {
-          console.warn(
-            `[PluginCapabilityGate] ${e.event} ${e.plugin_name}/${e.capability}`
-          );
+          console.warn(`[PluginCapabilityGate] ${e.event} ${e.plugin_name}/${e.capability}`);
         }
       });
     if (this.storageDir !== undefined) {
@@ -150,9 +137,7 @@ export class PluginCapabilityGate {
     } catch (err) {
       // write 실패 → in-memory 만 유지. 다음 process restart 시 재요청.
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[PluginCapabilityGate] persist failed for ${pluginName}/${capability}: ${msg}`
-      );
+      console.warn(`[PluginCapabilityGate] persist failed for ${pluginName}/${capability}: ${msg}`);
     }
   }
 
@@ -162,10 +147,7 @@ export class PluginCapabilityGate {
    *
    * @returns 모든 capability 승인됨 → true. 하나라도 거절 → false.
    */
-  async ensureGranted(
-    pluginName: string,
-    capabilities: ReadonlyArray<string>
-  ): Promise<boolean> {
+  async ensureGranted(pluginName: string, capabilities: ReadonlyArray<string>): Promise<boolean> {
     const grantedSet = this.granted.get(pluginName) ?? new Set<string>();
     const deniedSet = this.denied.get(pluginName) ?? new Set<string>();
     // Map 에 ref 가 새 Set 이면 방금 만든 것이라 set 에 등록.

--- a/src/main/plugins/PluginManager.ts
+++ b/src/main/plugins/PluginManager.ts
@@ -92,7 +92,9 @@ export class PluginManager {
       options.auditSink ??
       ((event): void => {
         if (event.event !== 'plugin.loaded') {
-          console.error(`[PluginManager] ${event.event} ${event.plugin_dir}: ${event.reason ?? ''}`);
+          console.error(
+            `[PluginManager] ${event.event} ${event.plugin_dir}: ${event.reason ?? ''}`
+          );
         }
       });
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -185,10 +185,7 @@ type NetworkSideEffectShape = {
   status?: number;
   host?: string;
 };
-type SideEffectShape =
-  | FileSideEffectShape
-  | ProcessSideEffectShape
-  | NetworkSideEffectShape;
+type SideEffectShape = FileSideEffectShape | ProcessSideEffectShape | NetworkSideEffectShape;
 
 interface ToolResultShape {
   call_id: string;
@@ -290,12 +287,7 @@ interface McpServerConfigShape {
   added_at: string;
 }
 
-type McpServerStatusShape =
-  | 'disconnected'
-  | 'connecting'
-  | 'ready'
-  | 'error'
-  | 'disabled';
+type McpServerStatusShape = 'disconnected' | 'connecting' | 'ready' | 'error' | 'disabled';
 
 interface McpToolInfoShape {
   name: string;
@@ -409,12 +401,7 @@ interface SearchTurnsArgsShape {
 // v0.12.0 (I) — Cross-AI Verify/Compare shapes. CompareStore 의 export 와
 // sync. preload 는 better-sqlite3 의 transitive import 를 피하기 위해 inline
 // 한다. main 의 zod CompareRunArgsSchema 가 IPC 경계에서 검증한다.
-type CompareSideStatusShape =
-  | 'pending'
-  | 'streaming'
-  | 'done'
-  | 'error'
-  | 'skipped';
+type CompareSideStatusShape = 'pending' | 'streaming' | 'done' | 'error' | 'skipped';
 type CompareRunStatusShape = 'running' | 'completed' | 'failed';
 type CompareSideShape = 'claude' | 'codex';
 
@@ -691,9 +678,7 @@ const api = {
     /**
      * v0.3.0 — wizard / 설정에서 호출. main 측 Zod 가 enum 검증.
      */
-    setDefaultProvider: (
-      provider: 'auto' | 'claude' | 'codex' | 'mock'
-    ): Promise<Result<void>> =>
+    setDefaultProvider: (provider: 'auto' | 'claude' | 'codex' | 'mock'): Promise<Result<void>> =>
       ipcRenderer.invoke('app:set-default-provider', provider) as Promise<Result<void>>,
 
     /**
@@ -729,14 +714,10 @@ const api = {
      * PermissionLevel 별로 plain string[] 를 반환 — IPC 직렬화 안전.
      */
     getPermissionCapabilities: (): Promise<
-      Result<
-        Record<'read_only' | 'workspace_write' | 'full_access' | 'custom', string[]>
-      >
+      Result<Record<'read_only' | 'workspace_write' | 'full_access' | 'custom', string[]>>
     > =>
       ipcRenderer.invoke('app:get-permission-capabilities') as Promise<
-        Result<
-          Record<'read_only' | 'workspace_write' | 'full_access' | 'custom', string[]>
-        >
+        Result<Record<'read_only' | 'workspace_write' | 'full_access' | 'custom', string[]>>
       >,
 
     /**
@@ -744,21 +725,15 @@ const api = {
      * 키: ShortcutAction, 값: combo 문자열 ("Mod+K"). 미설정 시 빈 object.
      */
     getKeyboardShortcuts: (): Promise<Result<Record<string, string>>> =>
-      ipcRenderer.invoke('app:get-keyboard-shortcuts') as Promise<
-        Result<Record<string, string>>
-      >,
+      ipcRenderer.invoke('app:get-keyboard-shortcuts') as Promise<Result<Record<string, string>>>,
 
     /**
      * v0.10.0 — 사용자 지정 매핑 영속. 빈 object 를 보내면 모든 override 제거.
      * action / combo 형식은 renderer 가 검증하고 main 은 plain string-string
      * 매핑만 보존.
      */
-    setKeyboardShortcuts: (
-      overrides: Record<string, string>
-    ): Promise<Result<void>> =>
-      ipcRenderer.invoke('app:set-keyboard-shortcuts', overrides) as Promise<
-        Result<void>
-      >,
+    setKeyboardShortcuts: (overrides: Record<string, string>): Promise<Result<void>> =>
+      ipcRenderer.invoke('app:set-keyboard-shortcuts', overrides) as Promise<Result<void>>,
 
     /**
      * v0.11.0 (B2) — Settings 모달 [언어] 탭. 'ko' default.
@@ -791,10 +766,7 @@ const api = {
      * v1.5.0 — Direct API key 설정. 빈 문자열을 보내면 해당 provider key 삭제.
      * provider 는 'anthropic' | 'openai' enum. main 측에서 zod-less 수동 검증.
      */
-    setDirectApiKey: (
-      provider: 'anthropic' | 'openai',
-      key: string
-    ): Promise<Result<void>> =>
+    setDirectApiKey: (provider: 'anthropic' | 'openai', key: string): Promise<Result<void>> =>
       ipcRenderer.invoke('app:set-direct-api-key', provider, key) as Promise<Result<void>>,
 
     /**
@@ -920,9 +892,7 @@ const api = {
      * 큰 monorepo 에선 ignore_patterns 를 신중히 지정하는 게 권장.
      */
     listFiles: (args: ListFilesArgsShape): Promise<Result<FileEntryShape[]>> =>
-      ipcRenderer.invoke('workspace/list-files', args) as Promise<
-        Result<FileEntryShape[]>
-      >,
+      ipcRenderer.invoke('workspace/list-files', args) as Promise<Result<FileEntryShape[]>>,
 
     /**
      * v0.6.0 (F-019) — workspace 내 단일 파일 read. 다음 케이스는 거절:
@@ -933,9 +903,7 @@ const api = {
      * 정상 read 라도 max_bytes 초과면 truncated=true + content 는 prefix.
      */
     readFile: (args: ReadFileArgsShape): Promise<Result<FileContentShape>> =>
-      ipcRenderer.invoke('workspace/read-file', args) as Promise<
-        Result<FileContentShape>
-      >,
+      ipcRenderer.invoke('workspace/read-file', args) as Promise<Result<FileContentShape>>,
   },
 
   /**
@@ -999,32 +967,22 @@ const api = {
      * 패턴으로 안전 렌더링해야 한다 (XSS 방어).
      */
     search: (args: SearchTurnsArgsShape): Promise<Result<TurnSearchResultShape[]>> =>
-      ipcRenderer.invoke('session/search', args) as Promise<
-        Result<TurnSearchResultShape[]>
-      >,
+      ipcRenderer.invoke('session/search', args) as Promise<Result<TurnSearchResultShape[]>>,
 
     /**
      * v0.8.0 — H Permission Dropdown 가 호출. 세션의 default_level 변경 후
      * 갱신된 Session 반환. main 측 Zod 가 enum 검증 + strict mode 로 unknown
      * field 거절.
      */
-    updatePermission: (
-      id: SessionId,
-      patch: PermissionPatch
-    ): Promise<Result<Session>> =>
-      ipcRenderer.invoke('session/update-permission', id, patch) as Promise<
-        Result<Session>
-      >,
+    updatePermission: (id: SessionId, patch: PermissionPatch): Promise<Result<Session>> =>
+      ipcRenderer.invoke('session/update-permission', id, patch) as Promise<Result<Session>>,
 
     /**
      * v1.1.11 (Workspace UX): per-session sticky workspace lock toggle.
      * ChatHeader 의 🔒 toggle 이 호출. main 측이 sessions.workspace_locked
      * 컬럼 갱신 후 ok 반환.
      */
-    setWorkspaceLocked: (
-      sessionId: SessionId,
-      locked: boolean
-    ): Promise<Result<{ ok: boolean }>> =>
+    setWorkspaceLocked: (sessionId: SessionId, locked: boolean): Promise<Result<{ ok: boolean }>> =>
       ipcRenderer.invoke('session/set-workspace-locked', {
         sessionId,
         locked,
@@ -1033,9 +991,7 @@ const api = {
     /**
      * v1.1.11: 특정 세션의 lock 상태 read — UI mount / 새 세션 전환 시 동기화.
      */
-    getWorkspaceLocked: (
-      sessionId: SessionId
-    ): Promise<Result<{ locked: boolean }>> =>
+    getWorkspaceLocked: (sessionId: SessionId): Promise<Result<{ locked: boolean }>> =>
       ipcRenderer.invoke('session/get-workspace-locked', sessionId) as Promise<
         Result<{ locked: boolean }>
       >,
@@ -1381,10 +1337,7 @@ const api = {
         Result<CompareRunShape | null>
       >,
 
-    list: (
-      sessionId: string,
-      limit?: number
-    ): Promise<Result<CompareRunShape[]>> =>
+    list: (sessionId: string, limit?: number): Promise<Result<CompareRunShape[]>> =>
       ipcRenderer.invoke(
         'compare/list',
         limit !== undefined ? { session_id: sessionId, limit } : { session_id: sessionId }
@@ -1394,10 +1347,7 @@ const api = {
       ipcRenderer.invoke('compare/cancel', { run_id: runId }) as Promise<Result<void>>,
 
     onStreamEvent: (listener: (event: CompareEventShape) => void): (() => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        payload: CompareEventShape
-      ): void => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: CompareEventShape): void => {
         listener(payload);
       };
       ipcRenderer.on('compare/stream-event', handler);
@@ -1419,10 +1369,7 @@ const api = {
       ipcRenderer.invoke('audit/recent', args ?? {}) as Promise<Result<AuditEventShape[]>>,
 
     /** 단일 세션의 audit event — 시간 ASC. limit default 500, max 5000. */
-    bySession: (
-      sessionId: string,
-      limit?: number
-    ): Promise<Result<AuditEventShape[]>> =>
+    bySession: (sessionId: string, limit?: number): Promise<Result<AuditEventShape[]>> =>
       ipcRenderer.invoke(
         'audit/by-session',
         limit !== undefined ? { session_id: sessionId, limit } : { session_id: sessionId }
@@ -1443,9 +1390,7 @@ const api = {
    */
   permission: {
     /** main → renderer 의 permission/request 구독. unsubscribe 함수 반환. */
-    onRequest: (
-      listener: (request: PermissionRequestShape) => void
-    ): (() => void) => {
+    onRequest: (listener: (request: PermissionRequestShape) => void): (() => void) => {
       const handler = (
         _event: Electron.IpcRendererEvent,
         payload: PermissionRequestShape
@@ -1469,14 +1414,10 @@ const api = {
 
     /** UI mount/reload 시 — 진행 중 요청 다시 받아 inline card 복원. */
     listPending: (): Promise<Result<PermissionRequestShape[]>> =>
-      ipcRenderer.invoke('permission/list-pending') as Promise<
-        Result<PermissionRequestShape[]>
-      >,
+      ipcRenderer.invoke('permission/list-pending') as Promise<Result<PermissionRequestShape[]>>,
 
     /** Settings > 권한 — active grant 목록 (revoked 제외). */
-    listGrants: (
-      sessionId: string
-    ): Promise<Result<PermissionGrantSummaryShape[]>> =>
+    listGrants: (sessionId: string): Promise<Result<PermissionGrantSummaryShape[]>> =>
       ipcRenderer.invoke('permission/grants/list', { session_id: sessionId }) as Promise<
         Result<PermissionGrantSummaryShape[]>
       >,
@@ -1496,25 +1437,16 @@ const api = {
    */
   automation: {
     list: (): Promise<Result<AutomationRuleSummaryShape[]>> =>
-      ipcRenderer.invoke('automation/list') as Promise<
-        Result<AutomationRuleSummaryShape[]>
-      >,
-    register: (
-      rule: AutomationRuleRegisterShape
-    ): Promise<Result<AutomationRuleSummaryShape>> =>
+      ipcRenderer.invoke('automation/list') as Promise<Result<AutomationRuleSummaryShape[]>>,
+    register: (rule: AutomationRuleRegisterShape): Promise<Result<AutomationRuleSummaryShape>> =>
       ipcRenderer.invoke('automation/register', rule) as Promise<
         Result<AutomationRuleSummaryShape>
       >,
     unregister: (name: string): Promise<Result<{ removed: boolean }>> =>
-      ipcRenderer.invoke('automation/unregister', name) as Promise<
-        Result<{ removed: boolean }>
-      >,
+      ipcRenderer.invoke('automation/unregister', name) as Promise<Result<{ removed: boolean }>>,
     fire: (name: string): Promise<Result<void>> =>
       ipcRenderer.invoke('automation/fire', name) as Promise<Result<void>>,
-    getNextRun: (
-      cronExpr: string,
-      tz?: string
-    ): Promise<Result<{ next_run: string | null }>> =>
+    getNextRun: (cronExpr: string, tz?: string): Promise<Result<{ next_run: string | null }>> =>
       ipcRenderer.invoke('automation/get-next-run', cronExpr, tz) as Promise<
         Result<{ next_run: string | null }>
       >,
@@ -1522,18 +1454,11 @@ const api = {
     listHandlers: (): Promise<Result<string[]>> =>
       ipcRenderer.invoke('automation/list-handlers') as Promise<Result<string[]>>,
     /** v1.7.26 — Automation audit log 최근 N개 조회. rule_name 필터 지원. */
-    auditLog: (opts?: {
-      rule_name?: string;
-      limit?: number;
-    }): Promise<Result<AuditEventShape[]>> =>
-      ipcRenderer.invoke('automation/audit-log', opts) as Promise<
-        Result<AuditEventShape[]>
-      >,
+    auditLog: (opts?: { rule_name?: string; limit?: number }): Promise<Result<AuditEventShape[]>> =>
+      ipcRenderer.invoke('automation/audit-log', opts) as Promise<Result<AuditEventShape[]>>,
     /** v1.7.27 — rule 활성화/비활성화 토글. */
     setEnabled: (name: string, enabled: boolean): Promise<Result<boolean>> =>
-      ipcRenderer.invoke('automation/set-enabled', { name, enabled }) as Promise<
-        Result<boolean>
-      >,
+      ipcRenderer.invoke('automation/set-enabled', { name, enabled }) as Promise<Result<boolean>>,
     /** v1.7.28 — Rules JSON export. handler closure 제외, settings 영속 shape 만 직렬화. */
     exportRules: (): Promise<Result<string>> =>
       ipcRenderer.invoke('automation/export') as Promise<Result<string>>,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -285,11 +285,7 @@ export function readSettings(): AppSettings {
           if (item === null || typeof item !== 'object') continue;
           const r = item as Record<string, unknown>;
           if (typeof r['name'] !== 'string' || r['name'].length === 0) continue;
-          if (
-            r['kind'] !== 'interval' &&
-            r['kind'] !== 'cron' &&
-            r['kind'] !== 'webhook'
-          ) {
+          if (r['kind'] !== 'interval' && r['kind'] !== 'cron' && r['kind'] !== 'webhook') {
             continue;
           }
           const persisted: AutomationRulePersisted = {
@@ -305,17 +301,11 @@ export function readSettings(): AppSettings {
           if (typeof r['cron_tz'] === 'string' && r['cron_tz'].length > 0) {
             persisted.cron_tz = r['cron_tz'];
           }
-          if (
-            typeof r['webhook_path'] === 'string' &&
-            r['webhook_path'].length > 0
-          ) {
+          if (typeof r['webhook_path'] === 'string' && r['webhook_path'].length > 0) {
             persisted.webhook_path = r['webhook_path'];
           }
           // v1.7.23 — handler_name / handler_config. 손상된 항목 silent drop.
-          if (
-            typeof r['handler_name'] === 'string' &&
-            r['handler_name'].length > 0
-          ) {
+          if (typeof r['handler_name'] === 'string' && r['handler_name'].length > 0) {
             persisted.handler_name = r['handler_name'];
           }
           if (

--- a/src/main/telemetry/SentryAdapter.ts
+++ b/src/main/telemetry/SentryAdapter.ts
@@ -26,14 +26,8 @@ import type { SentryClientLike } from './Telemetry';
  */
 export interface SentryNamespaceLike {
   init: (options: SentryInitOptionsLike) => void;
-  captureException: (
-    error: Error | string,
-    hint?: SentryHintLike
-  ) => unknown;
-  captureMessage: (
-    message: string,
-    levelOrHint?: SentryLevelLike | SentryHintLike
-  ) => unknown;
+  captureException: (error: Error | string, hint?: SentryHintLike) => unknown;
+  captureMessage: (message: string, levelOrHint?: SentryLevelLike | SentryHintLike) => unknown;
   /**
    * Sentry node SDK 의 `metrics.distribution`. 일부 버전 / 빌드에는 없을 수
    * 있어 optional.

--- a/src/main/telemetry/Telemetry.ts
+++ b/src/main/telemetry/Telemetry.ts
@@ -54,7 +54,10 @@ class ConsoleSink implements TelemetrySink {
 
 export interface SentryClientLike {
   /** error kind — `Sentry.captureException` 와 호환. */
-  captureException(error: Error | string, hint?: { tags?: Record<string, string>; extra?: Record<string, unknown> }): void;
+  captureException(
+    error: Error | string,
+    hint?: { tags?: Record<string, string>; extra?: Record<string, unknown> }
+  ): void;
   /** event kind — `Sentry.captureMessage` 와 호환. */
   captureMessage(
     message: string,
@@ -120,9 +123,10 @@ export class SentrySink implements TelemetrySink {
  * Context 의 string 값 (≤ 64자) 은 tags 로, 그 외 (긴 string / number / boolean)
  * 는 extra 로 분리. Sentry tag 는 indexable 하지만 길이/타입 제약 있음.
  */
-function splitContext(
-  ctx: Record<string, string | number | boolean> | undefined
-): { tags?: Record<string, string>; extra?: Record<string, unknown> } {
+function splitContext(ctx: Record<string, string | number | boolean> | undefined): {
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+} {
   if (ctx === undefined) return {};
   const tags: Record<string, string> = {};
   const extra: Record<string, unknown> = {};
@@ -164,10 +168,19 @@ export class Telemetry {
     this.sink = sink;
   }
 
-  error(name: string, error: string | Error, context?: Record<string, string | number | boolean>): void {
+  error(
+    name: string,
+    error: string | Error,
+    context?: Record<string, string | number | boolean>
+  ): void {
     if (!this.enabled) return;
-    const errStr = error instanceof Error ? error.stack ?? error.message : error;
-    this.sink.emit({ kind: 'error', name, error: errStr, ...(context !== undefined && { context }) });
+    const errStr = error instanceof Error ? (error.stack ?? error.message) : error;
+    this.sink.emit({
+      kind: 'error',
+      name,
+      error: errStr,
+      ...(context !== undefined && { context }),
+    });
   }
 
   event(name: string, context?: Record<string, string | number | boolean>): void {

--- a/src/main/workspaceConflict.ts
+++ b/src/main/workspaceConflict.ts
@@ -80,16 +80,11 @@ function normalizePath(p: string): string {
  * @param picked 사용자가 고르거나 저장된 workspace path.
  * @param userDataDir Electron app.getPath('userData') 값.
  */
-export function checkUserDataConflict(
-  picked: string,
-  userDataDir: string
-): string | null {
+export function checkUserDataConflict(picked: string, userDataDir: string): string | null {
   const normalizedPicked = normalizePath(picked);
   const normalizedUd = normalizePath(userDataDir);
-  const a =
-    process.platform === 'win32' ? normalizedPicked.toLowerCase() : normalizedPicked;
-  const b =
-    process.platform === 'win32' ? normalizedUd.toLowerCase() : normalizedUd;
+  const a = process.platform === 'win32' ? normalizedPicked.toLowerCase() : normalizedPicked;
+  const b = process.platform === 'win32' ? normalizedUd.toLowerCase() : normalizedUd;
 
   if (a === b) {
     return `선택한 폴더 "${picked}" 가 앱 데이터 폴더 "${userDataDir}" 와 정확히 같아요. SQLite WAL/journal 파일이 작업 폴더에 노출되면 위험합니다. 다른 폴더를 선택해주세요.`;
@@ -118,10 +113,8 @@ export function classifyUserDataConflict(
   // 일관 (둘은 동일 정규화를 거쳐야 — message 와 kind 가 분리되면 안 됨).
   const normalizedPicked = normalizePath(picked);
   const normalizedUd = normalizePath(userDataDir);
-  const a =
-    process.platform === 'win32' ? normalizedPicked.toLowerCase() : normalizedPicked;
-  const b =
-    process.platform === 'win32' ? normalizedUd.toLowerCase() : normalizedUd;
+  const a = process.platform === 'win32' ? normalizedPicked.toLowerCase() : normalizedPicked;
+  const b = process.platform === 'win32' ? normalizedUd.toLowerCase() : normalizedUd;
 
   if (a === b) return 'exact';
   if (a.startsWith(`${b}${path.sep}`) || a.startsWith(`${b}/`)) return 'child';

--- a/src/providers/ClaudeAdapter.ts
+++ b/src/providers/ClaudeAdapter.ts
@@ -143,9 +143,10 @@ export class ClaudeAdapter implements ProviderAdapter {
       case 'dom_dump': {
         // v1.6.2 — DOM dump. Claude 에는 페이지 URL + structured JSON dump 를
         // fenced code block 으로 전달. node_count / summary 는 사용자 hint.
-        const sel = block.selector !== undefined && block.selector.length > 0
-          ? ` selector="${block.selector}"`
-          : '';
+        const sel =
+          block.selector !== undefined && block.selector.length > 0
+            ? ` selector="${block.selector}"`
+            : '';
         const header = `[DOM] ${block.url}${sel} — ${block.summary}`;
         const fenced = '```json\n' + block.dump_json + '\n```';
         return { type: 'text', text: `${header}\n${fenced}` };
@@ -155,9 +156,8 @@ export class ClaudeAdapter implements ProviderAdapter {
         const bb = block.bounding_box;
         const head = `[Annotation] ${block.url} (bbox ${bb.x},${bb.y},${bb.w}×${bb.h})`;
         const cmt = block.comment.length > 0 ? `\n주석: ${block.comment}` : '';
-        const shot = block.screenshot_uri !== undefined
-          ? `\n스크린샷: ${block.screenshot_uri}`
-          : '';
+        const shot =
+          block.screenshot_uri !== undefined ? `\n스크린샷: ${block.screenshot_uri}` : '';
         return { type: 'text', text: `${head}${cmt}${shot}` };
       }
     }

--- a/src/providers/CodexAdapter.ts
+++ b/src/providers/CodexAdapter.ts
@@ -290,8 +290,7 @@ export class CodexAdapter implements ProviderAdapter {
     const bb = block.bounding_box;
     const head = `[Annotation] ${block.url} (bbox ${bb.x},${bb.y},${bb.w}×${bb.h})`;
     const cmt = block.comment.length > 0 ? `\n주석: ${block.comment}` : '';
-    const shot =
-      block.screenshot_uri !== undefined ? `\n스크린샷: ${block.screenshot_uri}` : '';
+    const shot = block.screenshot_uri !== undefined ? `\n스크린샷: ${block.screenshot_uri}` : '';
     return `${head}${cmt}${shot}`;
   }
 

--- a/src/providers/api/AnthropicProvider.ts
+++ b/src/providers/api/AnthropicProvider.ts
@@ -195,9 +195,7 @@ function* translateAnthropicEvent(
             ? usage.cache_creation_input_tokens
             : 0;
         const cacheRead =
-          typeof usage.cache_read_input_tokens === 'number'
-            ? usage.cache_read_input_tokens
-            : 0;
+          typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
         yield {
           type: 'usage',
           data: {

--- a/src/providers/api/OpenAIProvider.ts
+++ b/src/providers/api/OpenAIProvider.ts
@@ -187,8 +187,7 @@ function* translateOpenAiEvent(
   const usage = obj.usage as Record<string, unknown> | undefined;
   if (usage !== undefined) {
     const inputTokens = typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0;
-    const outputTokens =
-      typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0;
+    const outputTokens = typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0;
     yield {
       type: 'usage',
       data: {

--- a/src/providers/cli/detect.ts
+++ b/src/providers/cli/detect.ts
@@ -112,8 +112,8 @@ async function execPathLookup(cmd: string, binaryName: string): Promise<string |
     if (lower.endsWith('.cmd')) return 0;
     if (lower.endsWith('.exe')) return 0;
     if (lower.endsWith('.bat')) return 0;
-    if (lower.endsWith('.ps1')) return 2;  // PowerShell needs `shell:true` to spawn
-    return 3;  // extensionless unix wrapper — last resort
+    if (lower.endsWith('.ps1')) return 2; // PowerShell needs `shell:true` to spawn
+    return 3; // extensionless unix wrapper — last resort
   };
   const sorted = [...lines].sort((a, b) => priority(a) - priority(b));
   return sorted[0] ?? null;

--- a/src/providers/cli/spawnSafe.ts
+++ b/src/providers/cli/spawnSafe.ts
@@ -111,11 +111,9 @@ export async function ensureAsciiCwd(cwd: string | undefined): Promise<string | 
     let child: ChildProcess;
     try {
       // `for %I in (...)` 안의 quoted path 를 cmd.exe 가 GetShortPathName 로 변환.
-      child = spawn(
-        'cmd.exe',
-        ['/d', '/s', '/c', `for %I in ("${cwd}") do @echo %~sI`],
-        { shell: false }
-      );
+      child = spawn('cmd.exe', ['/d', '/s', '/c', `for %I in ("${cwd}") do @echo %~sI`], {
+        shell: false,
+      });
     } catch {
       finish(cwd);
       return;

--- a/src/providers/cli/translateClaudeJsonl.ts
+++ b/src/providers/cli/translateClaudeJsonl.ts
@@ -138,8 +138,7 @@ export function translateClaudeJsonl(parsed: unknown, ctx: TranslateContext): St
       const tokens = parseClaudeUsage(usageRaw);
       const cliCost = obj.total_cost_usd;
       // CLI 가 직접 cost 를 줬으면 found=true (제공자 신뢰), 아니면 priceUsage.
-      const cliCostValid =
-        typeof cliCost === 'number' && Number.isFinite(cliCost) && cliCost >= 0;
+      const cliCostValid = typeof cliCost === 'number' && Number.isFinite(cliCost) && cliCost >= 0;
       const priced = priceUsage(ctx.model, tokens);
       const cost = cliCostValid
         ? Math.round((cliCost as number) * 1_000_000) / 1_000_000

--- a/src/providers/cli/vcrLoader.ts
+++ b/src/providers/cli/vcrLoader.ts
@@ -29,7 +29,10 @@ export class VcrFixtureMissingError extends Error {
 }
 
 export class VcrFixtureInvalidError extends Error {
-  constructor(public readonly path: string, message: string) {
+  constructor(
+    public readonly path: string,
+    message: string
+  ) {
     super(`VCR fixture invalid (${path}): ${message}`);
     this.name = 'VcrFixtureInvalidError';
   }
@@ -200,10 +203,7 @@ export function detectDrift(
  *
  * Codex Q10 picking: manual record (auto-overwrite on nightly fail X).
  */
-export function updateFixtureHash(
-  fixturePath: string,
-  capturedEvents: StreamEvent[]
-): void {
+export function updateFixtureHash(fixturePath: string, capturedEvents: StreamEvent[]): void {
   const fixture = loadFixture(fixturePath);
   const hash = eventsHashOf(capturedEvents);
   const updated: VcrFixture = {

--- a/src/providers/pricing.ts
+++ b/src/providers/pricing.ts
@@ -135,10 +135,7 @@ export function estimateCostUsd(model: string, usage: UsageInputs): number {
  * COST-2 의 hard limit gate 가 found=false 인 경우 unknown 정책 (기본 차단)
  * 적용. UsageStore.recordEvent 도 unknown 플래그 동시 영속.
  */
-export function priceUsage(
-  model: string,
-  usage: UsageInputs
-): { usd: number; found: boolean } {
+export function priceUsage(model: string, usage: UsageInputs): { usd: number; found: boolean } {
   const pricing = lookupPricing(model);
   if (pricing === null) {
     return { usd: 0, found: false };
@@ -149,8 +146,7 @@ export function priceUsage(
 
   const inputCost = (usage.input_tokens / 1_000_000) * pricing.input_per_mtok;
   const outputCost = (usage.output_tokens / 1_000_000) * pricing.output_per_mtok;
-  const cacheWriteCost =
-    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWritePer;
+  const cacheWriteCost = ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWritePer;
   const cacheReadCost = ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * cacheReadPer;
 
   const total = inputCost + outputCost + cacheWriteCost + cacheReadCost;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -258,9 +258,7 @@ export function App(): React.JSX.Element {
   // 숨기고 chat 만 풀폭. 진입 직전 sidebar/preview 상태를 ref 에 저장 →
   // 토글 OFF 시 정확히 복원. ref 만으로 충분 (별도 상태 없이 snapshot 의
   // 존재 자체가 fullscreen 진입 여부를 나타냄).
-  const fullscreenSnapshotRef = useRef<{ sidebar: boolean; preview: boolean } | null>(
-    null
-  );
+  const fullscreenSnapshotRef = useRef<{ sidebar: boolean; preview: boolean } | null>(null);
   // v0.7.0 (F-026) — Sidebar 메시지 검색 state. 입력은 즉시 반영, 실제 IPC
   // 호출은 300ms debounce 후 별도 useEffect 가 트리거. results / error /
   // loading 은 IPC 응답에 따라 갱신. pendingFocusTurnId 는 사용자가 검색 결과
@@ -458,8 +456,7 @@ export function App(): React.JSX.Element {
     let cancelled = false;
     setSearchLoading(true);
     const timer = setTimeout(() => {
-      const sessApi =
-        typeof window !== 'undefined' ? window.dreampia?.session : undefined;
+      const sessApi = typeof window !== 'undefined' ? window.dreampia?.session : undefined;
       // search method 가 미정 (구버전 preload, 또는 mock 미설정) 이면 silent
       // fallback — UI 는 빈 결과 + loading=false 로 종료.
       if (sessApi === undefined || typeof sessApi.search !== 'function') {
@@ -499,13 +496,10 @@ export function App(): React.JSX.Element {
 
   // v0.7.0 (F-026) — 검색 결과 클릭 → 활성 세션 전환 + scroll target 보관.
   // ChatPanel 이 다음 render cycle 에 pendingFocusTurnId 를 보고 scrollIntoView.
-  const handleSearchResultClick = useCallback(
-    (sessionId: string, turnId: string): void => {
-      setActiveSessionId(sessionId);
-      setPendingFocusTurnId(turnId);
-    },
-    []
-  );
+  const handleSearchResultClick = useCallback((sessionId: string, turnId: string): void => {
+    setActiveSessionId(sessionId);
+    setPendingFocusTurnId(turnId);
+  }, []);
 
   // ChatPanel 의 onTurnFocused — scroll 끝나면 pendingFocusTurnId 를 비워야
   // 다음 검색 클릭이 다시 동작.
@@ -590,13 +584,7 @@ export function App(): React.JSX.Element {
     if (created !== null) {
       setActiveSessionId(created.id);
     }
-  }, [
-    createSession,
-    defaultWorkspace,
-    defaultPermissionLevel,
-    pickWorkspace,
-    sessions.length,
-  ]);
+  }, [createSession, defaultWorkspace, defaultPermissionLevel, pickWorkspace, sessions.length]);
 
   // v0.5.0 (F-018) — `/clear` 슬래시 명령. 활성 세션의 turn 만 비우고 session
   // 자체는 유지. local activeSession shadow 도 즉시 갱신해 UI 가 빠르게 반응.
@@ -689,10 +677,7 @@ export function App(): React.JSX.Element {
     setWorkspaceLocked(next);
     void (async () => {
       try {
-        const result = await sessionApi.setWorkspaceLocked(
-          activeSession.id as SessionId,
-          next
-        );
+        const result = await sessionApi.setWorkspaceLocked(activeSession.id as SessionId, next);
         if (!result.ok) {
           // IPC 실패 → 원복 + 사용자 알림 (v1.1.25 — silent fail X).
           setWorkspaceLocked(!next);
@@ -720,8 +705,7 @@ export function App(): React.JSX.Element {
   const handleForkSession = useCallback(
     async (truncateAt: string | undefined): Promise<void> => {
       if (activeSession === null) return;
-      const sessionApi =
-        typeof window !== 'undefined' ? window.dreampia?.session : undefined;
+      const sessionApi = typeof window !== 'undefined' ? window.dreampia?.session : undefined;
       if (sessionApi?.fork === undefined) {
         toasts.warning(t('toast.fork.no_ipc'));
         return;
@@ -968,19 +952,12 @@ export function App(): React.JSX.Element {
       }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    activeSession?.id,
-    chatHeaderWorkspaceName,
-    sessionWorkspaceName,
-    workspaceLocked,
-  ]);
+  }, [activeSession?.id, chatHeaderWorkspaceName, sessionWorkspaceName, workspaceLocked]);
 
   // v0.5.0 (F-018) — slash command handler 맵. ChatInput 으로 forward 되어
   // 사용자가 `/help`, `/clear` 등을 입력했을 때 호출된다. 인자가 없는 명령은
   // arg 인자를 무시한다. KNOWN_MODELS 화이트리스트는 `/model` 에서만 사용.
-  const commandHandlers = useMemo<
-    Partial<Record<SlashCommandId, (arg?: string) => void>>
-  >(
+  const commandHandlers = useMemo<Partial<Record<SlashCommandId, (arg?: string) => void>>>(
     () => ({
       help: () => {
         setSlashHelpOpen(true);
@@ -1035,8 +1012,7 @@ export function App(): React.JSX.Element {
         // v1.0.13 (WS-1): defaultWorkspace 우선, 그 다음 session.workspace.root.
         // v1.0.5 의 workspace drift fix 누락 부분 청산 — 사용자가 /project
         // 로 폴더 변경 후 /compare 했을 때 옛 폴더로 가던 회귀 방지.
-        const compareWorkspaceRoot =
-          defaultWorkspace?.root ?? activeSession.workspace.root;
+        const compareWorkspaceRoot = defaultWorkspace?.root ?? activeSession.workspace.root;
         void compareHook.start({
           prompt: arg,
           session_id: activeSession.id,
@@ -1143,13 +1119,7 @@ export function App(): React.JSX.Element {
         setPendingPrompt(firstPrompt);
       }
     },
-    [
-      completeOnboarding,
-      defaultWorkspace,
-      defaultPermissionLevel,
-      createSession,
-      sessions.length,
-    ]
+    [completeOnboarding, defaultWorkspace, defaultPermissionLevel, createSession, sessions.length]
   );
 
   const handleOnboardingSkip = useCallback(async (): Promise<void> => {
@@ -1173,9 +1143,7 @@ export function App(): React.JSX.Element {
   const keyboardHandlers = useMemo<Partial<Record<ShortcutAction, () => void>>>(() => {
     return {
       'search.focus': (): void => {
-        const el = document.querySelector<HTMLInputElement>(
-          '[data-testid="sidebar-search-input"]'
-        );
+        const el = document.querySelector<HTMLInputElement>('[data-testid="sidebar-search-input"]');
         if (el !== null) {
           // 사이드바가 collapse 되어 있으면 먼저 펼쳐 input 이 표시되도록.
           if (!sidebarVisible) setSidebarVisible(true);
@@ -1483,15 +1451,9 @@ export function App(): React.JSX.Element {
         }}
         onAccept={handleAcceptCompare}
       />
-      <PluginsModal
-        open={pluginsModalOpen}
-        onClose={() => setPluginsModalOpen(false)}
-      />
+      <PluginsModal open={pluginsModalOpen} onClose={() => setPluginsModalOpen(false)} />
       {/* v1.7.4 — Automation modal (Sidebar [자동화] 클릭). */}
-      <AutomationModal
-        open={automationModalOpen}
-        onClose={() => setAutomationModalOpen(false)}
-      />
+      <AutomationModal open={automationModalOpen} onClose={() => setAutomationModalOpen(false)} />
       {/* v1.4.8 — Workspace ID backfill prompt (boot effect 가 trigger). */}
       <BackfillPromptModal
         open={backfillModal !== null}
@@ -1515,11 +1477,7 @@ export function App(): React.JSX.Element {
               request={permission.current}
               onDecide={(decision, reason) => {
                 if (permission.current === null) return;
-                void permission.respond(
-                  permission.current.request_id,
-                  decision,
-                  reason
-                );
+                void permission.respond(permission.current.request_id, decision, reason);
               }}
             />
           </div>
@@ -1528,9 +1486,7 @@ export function App(): React.JSX.Element {
       {/* v1.1.0 SEC-2 full: dangerous 권한 요청 center modal escalation. */}
       <PermissionDangerModal
         request={
-          permission.current !== null && permission.current.is_dangerous
-            ? permission.current
-            : null
+          permission.current !== null && permission.current.is_dangerous ? permission.current : null
         }
         onDecide={(decision, reason) => {
           if (permission.current === null) return;

--- a/src/renderer/components/automation/AutomationModal.tsx
+++ b/src/renderer/components/automation/AutomationModal.tsx
@@ -53,9 +53,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
   const [auditEvents, setAuditEvents] = useState<AuditEventShape[]>([]);
   const [auditLoading, setAuditLoading] = useState(false);
   const [auditFilterRule, setAuditFilterRule] = useState<string>('');
-  const [auditFilterEvent, setAuditFilterEvent] = useState<
-    'all' | 'fired' | 'error'
-  >('all');
+  const [auditFilterEvent, setAuditFilterEvent] = useState<'all' | 'fired' | 'error'>('all');
 
   const handleToggleEnabled = async (name: string, currentEnabled: boolean): Promise<void> => {
     const api = typeof window !== 'undefined' ? window.dreampia?.automation : undefined;
@@ -178,8 +176,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
         return;
       }
     }
-    const handlerNameToUse =
-      draftHandlerName.length > 0 ? draftHandlerName : undefined;
+    const handlerNameToUse = draftHandlerName.length > 0 ? draftHandlerName : undefined;
 
     try {
       const base =
@@ -491,10 +488,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
             {loading ? (
               <p className="p-3 text-xs text-text-secondary">{t('automation.loading')}</p>
             ) : rules.length === 0 ? (
-              <p
-                className="p-3 text-xs text-text-tertiary"
-                data-testid="automation-empty"
-              >
+              <p className="p-3 text-xs text-text-tertiary" data-testid="automation-empty">
                 {t('automation.empty')}
               </p>
             ) : (
@@ -524,9 +518,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
                         {r.kind === 'cron' && (
                           <>
                             <span className="font-mono">{r.cron_expr}</span>
-                            {r.cron_tz !== undefined && (
-                              <span className="ml-2">@ {r.cron_tz}</span>
-                            )}
+                            {r.cron_tz !== undefined && <span className="ml-2">@ {r.cron_tz}</span>}
                             {r.next_run !== null && (
                               <span className="ml-2">
                                 {t('automation.next_label')}: {r.next_run}
@@ -535,9 +527,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
                           </>
                         )}
                         {r.kind === 'interval' && (
-                          <span>
-                            {t('automation.every', { ms: r.interval_ms ?? 0 })}
-                          </span>
+                          <span>{t('automation.every', { ms: r.interval_ms ?? 0 })}</span>
                         )}
                         {r.kind === 'webhook' && (
                           <span className="font-mono">POST {r.webhook_path}</span>
@@ -618,9 +608,7 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
                 </select>
                 <select
                   value={auditFilterEvent}
-                  onChange={(e) =>
-                    setAuditFilterEvent(e.target.value as 'all' | 'fired' | 'error')
-                  }
+                  onChange={(e) => setAuditFilterEvent(e.target.value as 'all' | 'fired' | 'error')}
                   className="rounded border border-border-primary bg-bg-secondary px-1 py-0.5 text-[10px]"
                   data-testid="automation-audit-filter-event"
                   aria-label={t('automation.audit_filter_event_aria')}
@@ -641,16 +629,15 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
               </div>
             </div>
             {auditLoading ? (
-              <p className="p-3 text-xs text-text-secondary">
-                {t('automation.audit_loading')}
-              </p>
-            ) : (() => {
+              <p className="p-3 text-xs text-text-secondary">{t('automation.audit_loading')}</p>
+            ) : (
+              (() => {
                 const visible = auditEvents.filter((e) =>
                   auditFilterEvent === 'all'
                     ? true
                     : auditFilterEvent === 'fired'
-                    ? e.event === 'automation.fired'
-                    : e.event === 'automation.error'
+                      ? e.event === 'automation.fired'
+                      : e.event === 'automation.error'
                 );
                 if (visible.length === 0) {
                   return (
@@ -725,7 +712,8 @@ export function AutomationModal({ open, onClose }: AutomationModalProps): React.
                     })}
                   </ul>
                 );
-              })()}
+              })()
+            )}
           </section>
         </div>
       </div>

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -24,10 +24,7 @@ import {
   type SlashCommand,
   type SlashCommandId,
 } from '../../commands/registry';
-import {
-  SlashCommandPopover,
-  commandOptionId,
-} from './SlashCommandPopover';
+import { SlashCommandPopover, commandOptionId } from './SlashCommandPopover';
 import {
   ChatInputSuggestionPopover,
   suggestionOptionId,
@@ -294,7 +291,10 @@ export function ChatInput({
     if (activeMention.kind === 'session') {
       const list = sessions ?? [];
       return list
-        .filter((s) => q.length === 0 || s.title.toLowerCase().includes(q) || s.id.toLowerCase().includes(q))
+        .filter(
+          (s) =>
+            q.length === 0 || s.title.toLowerCase().includes(q) || s.id.toLowerCase().includes(q)
+        )
         .slice(0, MENTION_SUGGESTION_LIMIT)
         .map(
           (s): MentionSuggestion => ({
@@ -440,9 +440,7 @@ export function ChatInput({
       for (const f of files) {
         const v = validateImageFile(f);
         if (!v.ok) {
-          console.warn(
-            `[ChatInput] file rejected: ${v.reason} (${f.name}, ${f.type}, ${f.size})`
-          );
+          console.warn(`[ChatInput] file rejected: ${v.reason} (${f.name}, ${f.type}, ${f.size})`);
           continue;
         }
         try {
@@ -453,9 +451,7 @@ export function ChatInput({
             const text = await pdfBase64ToChatText(result.base64, {
               filename: f.name,
             });
-            setValue((prev) =>
-              prev.length > 0 ? `${prev}\n\n${text}` : text
-            );
+            setValue((prev) => (prev.length > 0 ? `${prev}\n\n${text}` : text));
           } else {
             // v1.6.16 — Image → ImageBlock 으로 변환 후 부모에 forward.
             imageBlocks.push({
@@ -529,11 +525,7 @@ export function ChatInput({
     if (mentions.length === 0 || resolverContext === undefined) {
       // v1.6.13 — mention 이 없어도 pendingBlocks 가 있으면 typed-block 경로
       // 사용 (그래야 attached blocks 도 함께 전달).
-      if (
-        onSubmitBlocks !== undefined &&
-        pendingBlocks !== undefined &&
-        pendingBlocks.length > 0
-      ) {
+      if (onSubmitBlocks !== undefined && pendingBlocks !== undefined && pendingBlocks.length > 0) {
         onSubmitBlocks(text, [...pendingBlocks]);
         onConsumePendingBlocks?.();
         setValue('');
@@ -557,10 +549,7 @@ export function ChatInput({
     void (async () => {
       try {
         // v1.0.13 (MENT-1): resolveMentionsRich 가 limits 정보 같이 반환.
-        const { resolved, limits } = await resolveMentionsRich(
-          mentions,
-          resolverContext
-        );
+        const { resolved, limits } = await resolveMentionsRich(mentions, resolverContext);
         // 초과 시 사용자에게 "N개 / X KB 제외됨" 안내 (Codex 추가 권고).
         const summary = summarizeMentionLimits(limits);
         setMentionExclusion(summary);

--- a/src/renderer/components/chat/ChatInputSuggestionPopover.tsx
+++ b/src/renderer/components/chat/ChatInputSuggestionPopover.tsx
@@ -114,9 +114,7 @@ export function ChatInputSuggestionPopover<T extends SuggestionItem>({
         {items.map((item, index) => {
           const isActive = index === activeIndex;
           const optionTestid =
-            optionTestidPrefix !== undefined
-              ? `${optionTestidPrefix}-${item.id}`
-              : undefined;
+            optionTestidPrefix !== undefined ? `${optionTestidPrefix}-${item.id}` : undefined;
           return (
             <li
               key={item.id}

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -12,13 +12,7 @@
 
 import { useEffect, useRef } from 'react';
 import { ChatInput } from './ChatInput';
-import type {
-  ContentBlock,
-  PermissionLevel,
-  Session,
-  Turn,
-  ToolResultRef,
-} from '@/types';
+import type { ContentBlock, PermissionLevel, Session, Turn, ToolResultRef } from '@/types';
 import { EFFORT_LABELS_KO } from '@/types';
 import { FileReferenceChip } from './FileReferenceChip';
 import { SessionReferenceChip } from './SessionReferenceChip';
@@ -782,9 +776,7 @@ export function WelcomeMessage({
 }: WelcomeMessageProps): React.JSX.Element {
   const t = useT();
   const hasCtas =
-    onOpenAutomation !== undefined ||
-    onOpenPlugins !== undefined ||
-    onOpenHelp !== undefined;
+    onOpenAutomation !== undefined || onOpenPlugins !== undefined || onOpenHelp !== undefined;
   return (
     <div className="mx-auto mt-16 max-w-md text-center" data-testid="welcome-message">
       <div className="text-5xl" aria-hidden="true">
@@ -809,10 +801,7 @@ export function WelcomeMessage({
         })}
       </div>
       {hasCtas && (
-        <div
-          className="mt-6 space-y-2 text-left text-sm"
-          data-testid="welcome-cta-section"
-        >
+        <div className="mt-6 space-y-2 text-left text-sm" data-testid="welcome-cta-section">
           <p className="font-medium text-text-secondary">{t('chat.welcome.cta.label')}</p>
           {onOpenAutomation !== undefined && (
             <CtaChip onClick={onOpenAutomation} testId="welcome-cta-automation">

--- a/src/renderer/components/chat/CompareModal.tsx
+++ b/src/renderer/components/chat/CompareModal.tsx
@@ -169,9 +169,7 @@ export function CompareModal({
               title={run?.prompt ?? ''}
               data-testid="compare-prompt"
             >
-              {run !== null && run.prompt.length > 0
-                ? run.prompt
-                : t('compare.prompt.empty')}
+              {run !== null && run.prompt.length > 0 ? run.prompt : t('compare.prompt.empty')}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -239,12 +237,7 @@ interface SidePanelProps {
   onAccept: (side: CompareSide, text: string, model: string | null) => void;
 }
 
-function SidePanel({
-  side,
-  result,
-  isRunning,
-  onAccept,
-}: SidePanelProps): React.JSX.Element {
+function SidePanel({ side, result, isRunning, onAccept }: SidePanelProps): React.JSX.Element {
   const t = useT();
   const status: CompareSideStatus = result?.status ?? 'pending';
   const text = result?.text ?? '';

--- a/src/renderer/components/chat/ProviderDropdown.tsx
+++ b/src/renderer/components/chat/ProviderDropdown.tsx
@@ -31,12 +31,7 @@ import { useT } from '../../i18n';
 
 export type DefaultProviderChoice = 'auto' | 'claude' | 'codex' | 'mock';
 
-const PROVIDER_OPTIONS: ReadonlyArray<DefaultProviderChoice> = [
-  'auto',
-  'claude',
-  'codex',
-  'mock',
-];
+const PROVIDER_OPTIONS: ReadonlyArray<DefaultProviderChoice> = ['auto', 'claude', 'codex', 'mock'];
 
 export interface ProviderDropdownProps {
   /**
@@ -59,9 +54,7 @@ export function ProviderDropdown({
   controlled,
 }: ProviderDropdownProps): React.JSX.Element {
   const t = useT();
-  const [value, setValue] = useState<DefaultProviderChoice>(
-    controlled?.value ?? 'auto'
-  );
+  const [value, setValue] = useState<DefaultProviderChoice>(controlled?.value ?? 'auto');
   const [ipcAvailable, setIpcAvailable] = useState(false);
   const [loaded, setLoaded] = useState(controlled !== undefined);
 
@@ -111,8 +104,7 @@ export function ProviderDropdown({
         controlled.onChange(next);
         return;
       }
-      const appApi =
-        typeof window !== 'undefined' ? window.dreampia?.app : undefined;
+      const appApi = typeof window !== 'undefined' ? window.dreampia?.app : undefined;
       if (appApi === undefined || typeof appApi.setDefaultProvider !== 'function') {
         return;
       }
@@ -125,8 +117,7 @@ export function ProviderDropdown({
 
   // controlled 모드면 항상 enable. self-managed 일 땐 IPC 가용 + 초기 fetch
   // 완료까지 대기. 외부 disabled 는 모든 것을 오버라이드.
-  const isDisabled =
-    disabled ?? (controlled === undefined && (!ipcAvailable || !loaded));
+  const isDisabled = disabled ?? (controlled === undefined && (!ipcAvailable || !loaded));
   const currentLabel = t(`provider.dropdown.option.${value}`);
 
   return (

--- a/src/renderer/components/chat/SlashHelpModal.tsx
+++ b/src/renderer/components/chat/SlashHelpModal.tsx
@@ -16,11 +16,7 @@
 import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 import { SLASH_COMMANDS } from '../../commands/registry';
-import {
-  SHORTCUT_DEFS,
-  formatShortcut,
-  type ShortcutAction,
-} from '../../keyboard/shortcuts';
+import { SHORTCUT_DEFS, formatShortcut, type ShortcutAction } from '../../keyboard/shortcuts';
 import { useT } from '../../i18n';
 
 export interface SlashHelpModalProps {
@@ -28,10 +24,7 @@ export interface SlashHelpModalProps {
   onClose: () => void;
 }
 
-export function SlashHelpModal({
-  open,
-  onClose,
-}: SlashHelpModalProps): React.JSX.Element | null {
+export function SlashHelpModal({ open, onClose }: SlashHelpModalProps): React.JSX.Element | null {
   const t = useT();
   // v0.10.0 — 사용자가 지정한 keyboard overrides 를 IPC 에서 fetch 해 표시.
   // 미존재 / 실패 시 default 만 보여줌 (graceful).
@@ -180,11 +173,13 @@ export function SlashHelpModal({
         {/* Footer hint */}
         <div className="border-t border-border-primary px-4 py-2 text-xs text-text-tertiary">
           <kbd className="rounded bg-bg-tertiary px-1">↑</kbd>
-          <kbd className="ml-0.5 rounded bg-bg-tertiary px-1">↓</kbd> {t('slash_help.footer.navigate')}
+          <kbd className="ml-0.5 rounded bg-bg-tertiary px-1">↓</kbd>{' '}
+          {t('slash_help.footer.navigate')}
           <span className="mx-2">·</span>
           <kbd className="rounded bg-bg-tertiary px-1">Enter</kbd> {t('slash_help.footer.select')}
           <span className="mx-2">·</span>
-          <kbd className="rounded bg-bg-tertiary px-1">Tab</kbd> {t('slash_help.footer.autocomplete')}
+          <kbd className="rounded bg-bg-tertiary px-1">Tab</kbd>{' '}
+          {t('slash_help.footer.autocomplete')}
           <span className="mx-2">·</span>
           <kbd className="rounded bg-bg-tertiary px-1">Esc</kbd> {t('slash_help.footer.close')}
         </div>

--- a/src/renderer/components/cost/CostLimitModal.tsx
+++ b/src/renderer/components/cost/CostLimitModal.tsx
@@ -14,9 +14,7 @@
 
 import { useT } from '../../i18n';
 
-export type CostLimitBlockReason =
-  | 'limit_exceeded'
-  | 'unknown_model_under_limit';
+export type CostLimitBlockReason = 'limit_exceeded' | 'unknown_model_under_limit';
 
 export interface CostLimitModalProps {
   open: boolean;
@@ -48,13 +46,9 @@ export function CostLimitModal({
   if (!open) return null;
 
   const titleKey =
-    reason === 'unknown_model_under_limit'
-      ? 'cost.modal.unknown_title'
-      : 'cost.modal.limit_title';
+    reason === 'unknown_model_under_limit' ? 'cost.modal.unknown_title' : 'cost.modal.limit_title';
   const bodyKey =
-    reason === 'unknown_model_under_limit'
-      ? 'cost.modal.unknown_body'
-      : 'cost.modal.limit_body';
+    reason === 'unknown_model_under_limit' ? 'cost.modal.unknown_body' : 'cost.modal.limit_body';
 
   return (
     <div

--- a/src/renderer/components/empty/EmptyState.tsx
+++ b/src/renderer/components/empty/EmptyState.tsx
@@ -51,9 +51,7 @@ export function EmptyState({
       )}
       <p className="text-sm font-semibold text-text-secondary">{title}</p>
       {description !== undefined && (
-        <p className="max-w-[320px] text-xs leading-relaxed text-text-tertiary">
-          {description}
-        </p>
+        <p className="max-w-[320px] text-xs leading-relaxed text-text-tertiary">{description}</p>
       )}
       {action !== undefined && (
         <button

--- a/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -692,10 +692,7 @@ function McpMiniSection({
   onOpenMcpSettings?: () => void;
 }): React.JSX.Element {
   return (
-    <div
-      className="mt-5 border-t border-border-primary pt-4"
-      data-testid="onboarding-mcp-mini"
-    >
+    <div className="mt-5 border-t border-border-primary pt-4" data-testid="onboarding-mcp-mini">
       <header className="mb-2 flex items-center gap-2">
         <Server className="h-4 w-4 text-text-secondary" aria-hidden="true" />
         <p className="text-sm font-medium text-text-primary">MCP 서버 (선택)</p>
@@ -802,10 +799,7 @@ function WorkspaceStep({
       </button>
 
       {/* v0.3.0 — 기본 권한 preset */}
-      <div
-        className="mt-5 border-t border-border-primary pt-4"
-        data-testid="permission-selector"
-      >
+      <div className="mt-5 border-t border-border-primary pt-4" data-testid="permission-selector">
         <header className="mb-2 flex items-center gap-2">
           <ShieldCheck className="h-4 w-4 text-text-secondary" aria-hidden="true" />
           <p className="text-sm font-medium text-text-primary">AI 가 기본으로 가질 권한</p>
@@ -834,9 +828,7 @@ function WorkspaceStep({
                   />
                   <div className="flex-1">
                     <p className="text-text-primary">
-                      <span className="font-medium">
-                        {PERMISSION_LEVEL_LABELS_KO[opt.value]}
-                      </span>
+                      <span className="font-medium">{PERMISSION_LEVEL_LABELS_KO[opt.value]}</span>
                       {opt.value === 'workspace_write' && (
                         <span className="ml-2 rounded bg-accent/20 px-1.5 py-0.5 text-[10px] text-accent">
                           권장

--- a/src/renderer/components/permission/PermissionApprovalCard.tsx
+++ b/src/renderer/components/permission/PermissionApprovalCard.tsx
@@ -17,10 +17,7 @@
 
 import { useEffect, useState } from 'react';
 import { useT } from '../../i18n';
-import type {
-  PermissionRequestUi,
-  PermissionDecisionUi,
-} from '../../hooks/usePermissionRequests';
+import type { PermissionRequestUi, PermissionDecisionUi } from '../../hooks/usePermissionRequests';
 
 export interface PermissionApprovalCardProps {
   request: PermissionRequestUi;
@@ -56,15 +53,11 @@ export function PermissionApprovalCard({
 
       <dl className="mb-3 space-y-1 text-xs">
         <div className="flex items-baseline justify-between gap-3">
-          <dt className="flex-shrink-0 text-text-tertiary">
-            {t('permission.card.capability')}
-          </dt>
+          <dt className="flex-shrink-0 text-text-tertiary">{t('permission.card.capability')}</dt>
           <dd className="font-mono text-text-secondary">{request.capability}</dd>
         </div>
         <div className="flex items-baseline justify-between gap-3">
-          <dt className="flex-shrink-0 text-text-tertiary">
-            {t('permission.card.target')}
-          </dt>
+          <dt className="flex-shrink-0 text-text-tertiary">{t('permission.card.target')}</dt>
           <dd className="break-all font-mono text-text-secondary">
             {request.target.kind}: {request.target.value || '(global)'}
           </dd>

--- a/src/renderer/components/permission/PermissionDangerModal.tsx
+++ b/src/renderer/components/permission/PermissionDangerModal.tsx
@@ -10,10 +10,7 @@
 
 import { useState, useEffect } from 'react';
 import { useT } from '../../i18n';
-import type {
-  PermissionRequestUi,
-  PermissionDecisionUi,
-} from '../../hooks/usePermissionRequests';
+import type { PermissionRequestUi, PermissionDecisionUi } from '../../hooks/usePermissionRequests';
 
 export interface PermissionDangerModalProps {
   request: PermissionRequestUi | null;
@@ -51,9 +48,7 @@ export function PermissionDangerModal({
           ⚠ {t('permission.danger.title', { tool: request.tool_display_name })}
         </h3>
 
-        <p className="mb-3 text-sm text-text-secondary">
-          {t('permission.danger.body')}
-        </p>
+        <p className="mb-3 text-sm text-text-secondary">{t('permission.danger.body')}</p>
 
         {/* v1.1.2 hotfix (Codex Q8): high-risk capability 는 server-side 에서
             session/always 응답을 once 로 강제 다운그레이드 — 사용자가
@@ -67,15 +62,11 @@ export function PermissionDangerModal({
 
         <dl className="mb-3 space-y-1 rounded-md border border-red-600/30 bg-red-900/10 p-3 text-xs">
           <div className="flex items-baseline justify-between gap-3">
-            <dt className="flex-shrink-0 text-text-tertiary">
-              {t('permission.card.capability')}
-            </dt>
+            <dt className="flex-shrink-0 text-text-tertiary">{t('permission.card.capability')}</dt>
             <dd className="font-mono text-text-primary">{request.capability}</dd>
           </div>
           <div className="flex items-baseline justify-between gap-3">
-            <dt className="flex-shrink-0 text-text-tertiary">
-              {t('permission.card.target')}
-            </dt>
+            <dt className="flex-shrink-0 text-text-tertiary">{t('permission.card.target')}</dt>
             <dd className="break-all font-mono text-text-primary">
               {request.target.kind}: {request.target.value || '(global)'}
             </dd>

--- a/src/renderer/components/plugins/PluginsModal.tsx
+++ b/src/renderer/components/plugins/PluginsModal.tsx
@@ -112,9 +112,7 @@ export function PluginsModal({ open, onClose }: PluginsModalProps): React.JSX.El
             <>
               <p className="mb-3 text-xs text-text-tertiary">
                 {t('plugins.modal.root_dir_label')}{' '}
-                <code className="rounded bg-bg-tertiary px-1.5 py-0.5">
-                  {data.rootDir}
-                </code>
+                <code className="rounded bg-bg-tertiary px-1.5 py-0.5">{data.rootDir}</code>
               </p>
               {data.loaded.length === 0 && data.issues.length === 0 && (
                 <p
@@ -137,9 +135,7 @@ export function PluginsModal({ open, onClose }: PluginsModalProps): React.JSX.El
                         data-testid="plugins-modal-loaded-item"
                       >
                         <div className="flex items-baseline gap-2">
-                          <span className="font-mono text-sm font-semibold">
-                            {p.manifest.name}
-                          </span>
+                          <span className="font-mono text-sm font-semibold">{p.manifest.name}</span>
                           <span className="font-mono text-[11px] text-text-tertiary">
                             v{p.manifest.version}
                           </span>

--- a/src/renderer/components/preview/PreviewPanel.tsx
+++ b/src/renderer/components/preview/PreviewPanel.tsx
@@ -32,10 +32,7 @@ import { ArrowLeft, ArrowRight, RotateCw, Plus, Maximize2, X, Camera, Code } fro
 import type { BrowserState, SessionId } from '@/types';
 import { useBrowser, type BrowserTabUI } from '../../hooks/useBrowser';
 import { useT } from '../../i18n';
-import {
-  AnnotationOverlay,
-  type AnnotationBox,
-} from './AnnotationOverlay';
+import { AnnotationOverlay, type AnnotationBox } from './AnnotationOverlay';
 import type { AnnotationBlock, DomDumpBlock } from '@/types/conversation';
 
 const DEMO_URL = 'https://example.com';

--- a/src/renderer/components/settings/DiagnoseSettings.tsx
+++ b/src/renderer/components/settings/DiagnoseSettings.tsx
@@ -164,9 +164,7 @@ function TelemetrySection({ t }: SubProps): React.JSX.Element {
       className="mt-6 rounded-md border border-border-primary p-4"
       data-testid="settings-telemetry-section"
     >
-      <h4 className="mb-1 text-sm font-semibold">
-        {t('settings.diagnose.telemetry.title')}
-      </h4>
+      <h4 className="mb-1 text-sm font-semibold">{t('settings.diagnose.telemetry.title')}</h4>
       <p className="mb-3 text-xs text-text-secondary">
         {t('settings.diagnose.telemetry.description')}
       </p>
@@ -354,9 +352,7 @@ function AuditLogSection({ t }: SubProps): React.JSX.Element {
       <header className="mb-2 flex items-start justify-between gap-3">
         <div className="flex-1">
           <h4 className="text-sm font-semibold">{t('settings.diagnose.audit.title')}</h4>
-          <p className="text-xs text-text-tertiary">
-            {t('settings.diagnose.audit.description')}
-          </p>
+          <p className="text-xs text-text-tertiary">{t('settings.diagnose.audit.description')}</p>
         </div>
         <button
           type="button"
@@ -387,10 +383,7 @@ function AuditLogSection({ t }: SubProps): React.JSX.Element {
       ) : entries !== null && entries.length > 0 ? (
         <AuditTable entries={entries} t={t} />
       ) : (
-        <p
-          className="text-xs text-text-tertiary"
-          data-testid="settings-diagnose-audit-empty"
-        >
+        <p className="text-xs text-text-tertiary" data-testid="settings-diagnose-audit-empty">
           {t('settings.diagnose.audit.empty')}
         </p>
       )}
@@ -451,12 +444,8 @@ function AuditTable({
                   ) : null;
                 })()}
               </td>
-              <td className="py-1 pr-3 font-mono text-text-secondary">
-                {e.capability || '—'}
-              </td>
-              <td
-                className={`py-1 pr-3 font-mono ${auditOutcomeClass(e)}`}
-              >
+              <td className="py-1 pr-3 font-mono text-text-secondary">{e.capability || '—'}</td>
+              <td className={`py-1 pr-3 font-mono ${auditOutcomeClass(e)}`}>
                 {e.outcome ?? e.decision_reason}
               </td>
               <td className="py-1 font-mono text-text-tertiary">

--- a/src/renderer/components/settings/KeyboardSettings.tsx
+++ b/src/renderer/components/settings/KeyboardSettings.tsx
@@ -41,12 +41,7 @@ const CATEGORY_LABELS_KO: Record<ShortcutCategory, string> = {
   modal: '모달',
 };
 
-const CATEGORY_ORDER: ReadonlyArray<ShortcutCategory> = [
-  'navigation',
-  'settings',
-  'chat',
-  'modal',
-];
+const CATEGORY_ORDER: ReadonlyArray<ShortcutCategory> = ['navigation', 'settings', 'chat', 'modal'];
 
 /**
  * SettingsModal 의 [단축키] 탭에서 mount. 자체적으로 IPC fetch + save 처리.
@@ -104,9 +99,7 @@ export function KeyboardSettings(): React.JSX.Element {
           // default 를 유지한 채 사용자가 같은 값을 explicit 으로 입력해도
           // 의미가 같으므로 통과시킨다.
           if (otherCombo === other.default && combo === def.default) continue;
-          setError(
-            `${formatShortcut(combo)} 는 이미 "${other.label}" 에 사용 중입니다.`
-          );
+          setError(`${formatShortcut(combo)} 는 이미 "${other.label}" 에 사용 중입니다.`);
           setEditing(null);
           return;
         }
@@ -143,9 +136,7 @@ export function KeyboardSettings(): React.JSX.Element {
   }, [save]);
 
   // SHORTCUT_DEFS 를 카테고리 별로 그룹.
-  const grouped = useMemo<
-    Map<ShortcutCategory, ShortcutDef[]>
-  >(() => {
+  const grouped = useMemo<Map<ShortcutCategory, ShortcutDef[]>>(() => {
     const m = new Map<ShortcutCategory, ShortcutDef[]>();
     for (const def of SHORTCUT_DEFS) {
       const arr = m.get(def.category) ?? [];
@@ -159,10 +150,7 @@ export function KeyboardSettings(): React.JSX.Element {
   const hasAnyOverride = Object.keys(overrides).length > 0;
 
   return (
-    <section
-      className="flex-1 overflow-y-auto p-6"
-      data-testid="settings-keyboard-panel"
-    >
+    <section className="flex-1 overflow-y-auto p-6" data-testid="settings-keyboard-panel">
       <header className="mb-4 flex items-start justify-between gap-3">
         <div>
           <h3 className="flex items-center gap-2 text-base font-semibold">
@@ -170,8 +158,7 @@ export function KeyboardSettings(): React.JSX.Element {
             단축키
           </h3>
           <p className="text-xs text-text-secondary">
-            행을 [편집] 으로 누른 뒤 원하는 키 조합을 입력하면 즉시 적용됩니다.
-            {' '}
+            행을 [편집] 으로 누른 뒤 원하는 키 조합을 입력하면 즉시 적용됩니다.{' '}
             <code className="rounded bg-bg-tertiary px-1 font-mono">Mod</code> ={' '}
             {onMac ? '⌘ Cmd (macOS)' : 'Ctrl (Windows / Linux)'}.
           </p>
@@ -220,8 +207,7 @@ export function KeyboardSettings(): React.JSX.Element {
                     const combo = overrides[def.action] ?? def.default;
                     const isEditing = editing === def.action;
                     const isOverridden =
-                      overrides[def.action] !== undefined &&
-                      overrides[def.action] !== def.default;
+                      overrides[def.action] !== undefined && overrides[def.action] !== def.default;
                     return (
                       <li
                         key={def.action}

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -21,15 +21,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import {
-  X,
-  RefreshCw,
-  Trash2,
-  FileText,
-  Plus,
-  AlertCircle,
-  Sparkles,
-} from 'lucide-react';
+import { X, RefreshCw, Trash2, FileText, Plus, AlertCircle, Sparkles } from 'lucide-react';
 import {
   useMcp,
   type McpDiscoveryUI,
@@ -111,17 +103,7 @@ export function McpSettings({ open, onClose }: McpSettingsProps): React.JSX.Elem
  */
 export function McpSettingsPanel(): React.JSX.Element {
   const t = useT();
-  const {
-    servers,
-    loading,
-    error,
-    refresh,
-    add,
-    remove,
-    restart,
-    getLogs,
-    discover,
-  } = useMcp();
+  const { servers, loading, error, refresh, add, remove, restart, getLogs, discover } = useMcp();
   const [showAddForm, setShowAddForm] = useState(false);
   /** add form 의 초기값 — suggested server / discovered server 를 템플릿으로 제공. */
   const [addFormInitial, setAddFormInitial] = useState<McpServerConfigUI | null>(null);
@@ -203,9 +185,7 @@ export function McpSettingsPanel(): React.JSX.Element {
         {loading ? (
           <p className="text-sm text-text-secondary">{t('mcp.loading')}</p>
         ) : servers.length === 0 ? (
-          <div className="py-8 text-center text-sm text-text-secondary">
-            {t('mcp.empty')}
-          </div>
+          <div className="py-8 text-center text-sm text-text-secondary">{t('mcp.empty')}</div>
         ) : (
           <ul className="space-y-2" data-testid="mcp-server-list">
             {servers.map((server) => (

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -92,7 +92,11 @@ const TAB_ORDER: ReadonlyArray<TabSpec> = [
   // v1.5.0 — Direct API 탭. provider 다음에 두어 "어떤 provider 쓸지 → 어떻게
   // 인증할지" 동선이 자연스럽게 연결되도록.
   { id: 'direct_api', labelKey: 'settings.tab.direct_api', icon: <KeyRound className="h-4 w-4" /> },
-  { id: 'permission', labelKey: 'settings.tab.permission', icon: <ShieldCheck className="h-4 w-4" /> },
+  {
+    id: 'permission',
+    labelKey: 'settings.tab.permission',
+    icon: <ShieldCheck className="h-4 w-4" />,
+  },
   { id: 'theme', labelKey: 'settings.tab.theme', icon: <Palette className="h-4 w-4" /> },
   { id: 'keyboard', labelKey: 'settings.tab.keyboard', icon: <Keyboard className="h-4 w-4" /> },
   // v0.11.0 (B2) — 언어 탭. theme 와 keyboard 사이에 두는 게 자연스럽지만 이미
@@ -437,7 +441,10 @@ function DirectApiPanel(): React.JSX.Element {
     const trimmed = inputValue.trim();
     const isSaving = saving === provider;
     return (
-      <div className="rounded-md border border-border-primary p-3" data-testid={`settings-direct-api-${provider}`}>
+      <div
+        className="rounded-md border border-border-primary p-3"
+        data-testid={`settings-direct-api-${provider}`}
+      >
         <div className="mb-2 flex items-center justify-between">
           <label htmlFor={inputId} className="text-sm font-medium">
             {label}
@@ -595,7 +602,17 @@ function PermissionGrantsBlock(): React.JSX.Element {
     setError(null);
     const w = typeof window !== 'undefined' ? window : undefined;
     const sessionApi = w?.dreampia?.session;
-    const permApi = (w?.dreampia as { permission?: { listGrants: (id: string) => Promise<{ ok: boolean; value?: GrantSummary[]; error?: string }> } } | undefined)?.permission;
+    const permApi = (
+      w?.dreampia as
+        | {
+            permission?: {
+              listGrants: (
+                id: string
+              ) => Promise<{ ok: boolean; value?: GrantSummary[]; error?: string }>;
+            };
+          }
+        | undefined
+    )?.permission;
     if (sessionApi === undefined || permApi === undefined) {
       setLoading(false);
       return;
@@ -627,7 +644,15 @@ function PermissionGrantsBlock(): React.JSX.Element {
   const handleRevoke = useCallback(
     async (grantId: string): Promise<void> => {
       const w = typeof window !== 'undefined' ? window : undefined;
-      const permApi = (w?.dreampia as { permission?: { revokeGrant: (id: string) => Promise<{ ok: boolean; error?: unknown }> } } | undefined)?.permission;
+      const permApi = (
+        w?.dreampia as
+          | {
+              permission?: {
+                revokeGrant: (id: string) => Promise<{ ok: boolean; error?: unknown }>;
+              };
+            }
+          | undefined
+      )?.permission;
       if (permApi === undefined) {
         toasts?.warning(t('settings.permission.grants.error.no_ipc'));
         return;
@@ -686,10 +711,7 @@ function PermissionGrantsBlock(): React.JSX.Element {
       {loading ? (
         <p className="text-xs text-text-secondary">{t('settings.loading')}</p>
       ) : grants.length === 0 ? (
-        <p
-          className="text-xs text-text-tertiary"
-          data-testid="settings-permission-grants-empty"
-        >
+        <p className="text-xs text-text-tertiary" data-testid="settings-permission-grants-empty">
           {t('settings.permission.grants.empty')}
         </p>
       ) : (
@@ -753,7 +775,9 @@ function PermissionGrantsBlock(): React.JSX.Element {
 
 function shortTarget(targetJson: string): string {
   try {
-    const obj = JSON.parse(targetJson) as { target?: { kind?: string; path?: string; url?: string; domain?: string } };
+    const obj = JSON.parse(targetJson) as {
+      target?: { kind?: string; path?: string; url?: string; domain?: string };
+    };
     const t = obj.target;
     if (t === undefined) return targetJson;
     if (t.kind === 'path' && t.path !== undefined) return `path:${t.path}`;
@@ -770,9 +794,7 @@ function PermissionPanel(): React.JSX.Element {
   const t = useT();
   const toasts = useOptionalToasts();
   const [level, setLevel] = useState<PermissionLevel>('workspace_write');
-  const [capabilities, setCapabilities] = useState<
-    Record<PermissionLevel, string[]> | null
-  >(null);
+  const [capabilities, setCapabilities] = useState<Record<PermissionLevel, string[]> | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -808,10 +830,7 @@ function PermissionPanel(): React.JSX.Element {
       const prev = level;
       setLevel(next); // optimistic
       const appApi = typeof window !== 'undefined' ? window.dreampia?.app : undefined;
-      if (
-        appApi === undefined ||
-        typeof appApi.setDefaultPermissionLevel !== 'function'
-      ) {
+      if (appApi === undefined || typeof appApi.setDefaultPermissionLevel !== 'function') {
         toasts?.warning(t('settings.permission.error.no_ipc'));
         return;
       }

--- a/src/renderer/components/settings/UsageChart.tsx
+++ b/src/renderer/components/settings/UsageChart.tsx
@@ -52,10 +52,7 @@ interface DayBucket {
  * raw rows → 일자 → provider 합계로 reshape. 같은 날짜의 다른 provider 들이
  * 한 막대 안에 stacked 로 그려진다.
  */
-function bucketize(
-  rows: ReadonlyArray<DailyUsageRowUI>,
-  metric: 'tokens' | 'cost'
-): DayBucket[] {
+function bucketize(rows: ReadonlyArray<DailyUsageRowUI>, metric: 'tokens' | 'cost'): DayBucket[] {
   const map = new Map<string, DayBucket>();
   for (const r of rows) {
     let bucket = map.get(r.date);
@@ -191,13 +188,7 @@ export function UsageChart({
               strokeOpacity={0.1}
               strokeDasharray="2 2"
             />
-            <text
-              x={PAD_LEFT - 4}
-              y={t.y + 3}
-              textAnchor="end"
-              fill="currentColor"
-              opacity={0.6}
-            >
+            <text x={PAD_LEFT - 4} y={t.y + 3} textAnchor="end" fill="currentColor" opacity={0.6}>
               {formatTick(t.value)}
             </text>
           </g>

--- a/src/renderer/components/settings/UsageSettings.tsx
+++ b/src/renderer/components/settings/UsageSettings.tsx
@@ -135,17 +135,8 @@ export function UsageSettings({ open, onClose }: UsageSettingsProps): React.JSX.
  */
 export function UsageSettingsPanel(): React.JSX.Element {
   const t = useT();
-  const {
-    summary,
-    daily,
-    loading,
-    error,
-    lastRefreshedAt,
-    preset,
-    setPreset,
-    refresh,
-    exportCsv,
-  } = useUsage('7d');
+  const { summary, daily, loading, error, lastRefreshedAt, preset, setPreset, refresh, exportCsv } =
+    useUsage('7d');
 
   const handleRefresh = useCallback((): void => {
     void refresh();
@@ -238,9 +229,7 @@ export function UsageSettingsPanel(): React.JSX.Element {
         {loading ? (
           <p className="text-sm text-text-secondary">{t('usage.loading')}</p>
         ) : summary.length === 0 && daily.length === 0 ? (
-          <div className="py-12 text-center text-sm text-text-secondary">
-            {t('usage.empty')}
-          </div>
+          <div className="py-12 text-center text-sm text-text-secondary">{t('usage.empty')}</div>
         ) : (
           <>
             {/* Total card */}
@@ -325,9 +314,7 @@ function CostLimitSection({ currentMonthCost }: CostLimitSectionProps): React.JS
   // limits 가 로딩되면 input 의 default 값을 채움.
   useEffect(() => {
     if (limits === null) return;
-    setDraftLimit(
-      limits.cost_limit_usd !== undefined ? String(limits.cost_limit_usd) : ''
-    );
+    setDraftLimit(limits.cost_limit_usd !== undefined ? String(limits.cost_limit_usd) : '');
   }, [limits]);
 
   const threshold = limits?.alert_threshold ?? 0.8;
@@ -357,10 +344,18 @@ function CostLimitSection({ currentMonthCost }: CostLimitSectionProps): React.JS
   // 글자만 바꿔 영어용으로 합칠 수 있도록 단순 base label + 비율 함께 표시).
   const status = useMemo(() => {
     if (limitUsd === undefined) {
-      return { kind: 'unset' as const, label: t('usage.cost_limit.unset'), color: 'text-text-tertiary' };
+      return {
+        kind: 'unset' as const,
+        label: t('usage.cost_limit.unset'),
+        color: 'text-text-tertiary',
+      };
     }
     if (limitUsd === 0) {
-      return { kind: 'over' as const, label: t('usage.cost_limit.exceeded'), color: 'text-red-400' };
+      return {
+        kind: 'over' as const,
+        label: t('usage.cost_limit.exceeded'),
+        color: 'text-red-400',
+      };
     }
     const ratio = currentMonthCost / limitUsd;
     const pct = `${(ratio * 100).toFixed(0)}%`;
@@ -395,7 +390,10 @@ function CostLimitSection({ currentMonthCost }: CostLimitSectionProps): React.JS
         <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
           {t('usage.cost_limit')}
         </h3>
-        <span className={`ml-auto text-xs font-medium ${status.color}`} data-testid="cost-limit-status">
+        <span
+          className={`ml-auto text-xs font-medium ${status.color}`}
+          data-testid="cost-limit-status"
+        >
           {status.label}
         </span>
       </header>
@@ -406,10 +404,7 @@ function CostLimitSection({ currentMonthCost }: CostLimitSectionProps): React.JS
         <div className="space-y-2 text-xs">
           {/* 한도 입력 */}
           <div className="flex items-center gap-2">
-            <label
-              className="flex flex-1 items-center gap-2"
-              data-testid="cost-limit-input-label"
-            >
+            <label className="flex flex-1 items-center gap-2" data-testid="cost-limit-input-label">
               <span className="w-20 text-text-tertiary">{t('usage.cost_limit.input_label')}</span>
               <input
                 type="number"
@@ -507,10 +502,7 @@ function SummarySection({ rows }: SummarySectionProps): React.JSX.Element {
               const cacheTotal =
                 row.total_cache_creation + row.total_cache_read + row.total_reasoning;
               return (
-                <tr
-                  key={`${row.provider}/${row.model}`}
-                  className="border-t border-border-primary"
-                >
+                <tr key={`${row.provider}/${row.model}`} className="border-t border-border-primary">
                   <td className="p-2">
                     <span
                       className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs ${PROVIDER_BADGE_COLORS[row.provider]}`}
@@ -571,7 +563,10 @@ function DailySection({ rows }: DailySectionProps): React.JSX.Element {
           </thead>
           <tbody>
             {rows.map((row, idx) => (
-              <tr key={`${row.date}/${row.provider}/${idx}`} className="border-t border-border-primary">
+              <tr
+                key={`${row.date}/${row.provider}/${idx}`}
+                className="border-t border-border-primary"
+              >
                 <td className="p-2 font-mono text-xs">{row.date}</td>
                 <td className="p-2">
                   <span
@@ -638,9 +633,7 @@ function PricingFreshnessBanner(): React.JSX.Element | null {
         })}
       </p>
       {stale && (
-        <p className="mt-0.5 text-yellow-300/80">
-          {t('usage.pricing_freshness.stale_hint')}
-        </p>
+        <p className="mt-0.5 text-yellow-300/80">{t('usage.pricing_freshness.stale_hint')}</p>
       )}
     </div>
   );

--- a/src/renderer/components/sidebar/SearchSection.tsx
+++ b/src/renderer/components/sidebar/SearchSection.tsx
@@ -85,7 +85,10 @@ export function SearchSection({
           data-testid="sidebar-search-results"
         >
           {loading ? (
-            <p className="px-3 py-2 text-xs text-text-tertiary" data-testid="sidebar-search-loading">
+            <p
+              className="px-3 py-2 text-xs text-text-tertiary"
+              data-testid="sidebar-search-loading"
+            >
               {t('sidebar.search.loading')}
             </p>
           ) : error !== null ? (
@@ -97,10 +100,7 @@ export function SearchSection({
               {t('sidebar.search.error')}
             </p>
           ) : results.length === 0 ? (
-            <p
-              className="px-3 py-2 text-xs text-text-tertiary"
-              data-testid="sidebar-search-empty"
-            >
+            <p className="px-3 py-2 text-xs text-text-tertiary" data-testid="sidebar-search-empty">
               {t('sidebar.search.no_results')}
             </p>
           ) : (
@@ -117,14 +117,15 @@ export function SearchSection({
                   >
                     <span className="flex w-full items-center justify-between gap-2 text-[10px] uppercase tracking-wide text-text-tertiary">
                       <span className="truncate">
-                        {sessionTitleById?.get(r.session_id) ?? t('sidebar.search.fallback_session_title')}
+                        {sessionTitleById?.get(r.session_id) ??
+                          t('sidebar.search.fallback_session_title')}
                       </span>
                       <span className="shrink-0">
                         {r.role === 'user'
                           ? t('sidebar.search.role_user')
                           : r.role === 'assistant'
-                          ? t('sidebar.search.role_assistant')
-                          : r.role}
+                            ? t('sidebar.search.role_assistant')
+                            : r.role}
                       </span>
                     </span>
                     <SnippetText snippet={r.snippet} />

--- a/src/renderer/components/sidebar/Sidebar.tsx
+++ b/src/renderer/components/sidebar/Sidebar.tsx
@@ -364,10 +364,7 @@ function McpStatusIndicator({ onOpen }: { onOpen: () => void }): React.JSX.Eleme
       </span>
       <span className="flex-1 truncate">{t('sidebar.mcp.label')}</span>
       <span className="flex flex-shrink-0 items-center gap-1.5 text-xs text-text-tertiary">
-        <span
-          className={`inline-block h-2 w-2 rounded-full ${dotColor}`}
-          aria-hidden="true"
-        />
+        <span className={`inline-block h-2 w-2 rounded-full ${dotColor}`} aria-hidden="true" />
         {label}
       </span>
     </button>
@@ -415,9 +412,7 @@ function SidebarNavItem({
       title={comingSoon === true ? comingSoonHint : undefined}
       aria-disabled={isDisabled}
       className={`group flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left ${
-        isDisabled
-          ? 'cursor-not-allowed opacity-50'
-          : 'hover:bg-bg-tertiary'
+        isDisabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-tertiary'
       }`}
     >
       <span className="flex-shrink-0">{icon}</span>

--- a/src/renderer/components/workspace/BackfillPromptModal.tsx
+++ b/src/renderer/components/workspace/BackfillPromptModal.tsx
@@ -137,9 +137,7 @@ export function BackfillPromptModal({
       <div className="flex w-[520px] max-w-[95vw] flex-col rounded-lg border border-border-primary bg-bg-primary shadow-xl">
         <div className="flex items-center justify-between border-b border-border-primary p-4">
           <h2 className="text-lg font-semibold">
-            {result === null
-              ? t('workspace_backfill.title')
-              : t('workspace_backfill.done_title')}
+            {result === null ? t('workspace_backfill.title') : t('workspace_backfill.done_title')}
           </h2>
           <button
             type="button"
@@ -216,9 +214,7 @@ export function BackfillPromptModal({
                           data-testid={`workspace-backfill-conflict-${row.legacy_id}`}
                         >
                           <div className="min-w-0 flex-1">
-                            <div className="truncate font-mono text-[11px]">
-                              {row.root}
-                            </div>
+                            <div className="truncate font-mono text-[11px]">{row.root}</div>
                             <div className="text-[10px] text-text-tertiary">
                               {t('workspace_backfill.conflict_session_count', {
                                 n: row.session_count,
@@ -279,9 +275,7 @@ export function BackfillPromptModal({
                 className="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
                 data-testid="workspace-backfill-run"
               >
-                {busy
-                  ? t('workspace_backfill.running')
-                  : t('workspace_backfill.run')}
+                {busy ? t('workspace_backfill.running') : t('workspace_backfill.run')}
               </button>
             </>
           ) : (

--- a/src/renderer/hooks/useCompare.ts
+++ b/src/renderer/hooks/useCompare.ts
@@ -22,12 +22,7 @@ import type { PermissionLevel } from '@/types';
 
 export type CompareSide = 'claude' | 'codex';
 
-export type CompareSideStatus =
-  | 'pending'
-  | 'streaming'
-  | 'done'
-  | 'error'
-  | 'skipped';
+export type CompareSideStatus = 'pending' | 'streaming' | 'done' | 'error' | 'skipped';
 
 export type CompareRunStatus = 'running' | 'completed' | 'failed';
 
@@ -173,17 +168,13 @@ export function useCompare(args: UseCompareArgs = {}): UseCompareReturn {
 
   // Subscribe to compare/stream-event once on mount. Filter by activeRunIdRef.
   useEffect(() => {
-    const compareApi =
-      typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
+    const compareApi = typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
     if (compareApi === undefined || typeof compareApi.onStreamEvent !== 'function') {
       return undefined;
     }
     const unsubscribe = compareApi.onStreamEvent((event) => {
       // 이벤트 run_id 가 현재 active 가 아니면 무시 (다른 hook 인스턴스의 run).
-      if (
-        activeRunIdRef.current === null ||
-        event.run_id !== activeRunIdRef.current
-      ) {
+      if (activeRunIdRef.current === null || event.run_id !== activeRunIdRef.current) {
         // compare_start 는 첫 이벤트이므로 active 가 set 되어 있어야 한다.
         // 만약 race 로 activeRunIdRef 가 아직 set 되지 않은 상태에서 첫 이벤트가
         // 도달하면, 같은 run 이라고 간주해 적용.
@@ -201,61 +192,54 @@ export function useCompare(args: UseCompareArgs = {}): UseCompareReturn {
     return unsubscribe;
   }, []);
 
-  const start = useCallback(
-    async (input: CompareStartArgs): Promise<string | null> => {
-      const compareApi =
-        typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
-      if (compareApi === undefined || typeof compareApi.run !== 'function') {
-        onErrorRef.current?.('compare API unavailable');
-        return null;
-      }
-      // Optimistic init — UI 는 즉시 'pending' 양쪽 표시.
-      const placeholder: CompareRun = {
-        id: '',
+  const start = useCallback(async (input: CompareStartArgs): Promise<string | null> => {
+    const compareApi = typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
+    if (compareApi === undefined || typeof compareApi.run !== 'function') {
+      onErrorRef.current?.('compare API unavailable');
+      return null;
+    }
+    // Optimistic init — UI 는 즉시 'pending' 양쪽 표시.
+    const placeholder: CompareRun = {
+      id: '',
+      session_id: input.session_id,
+      prompt: input.prompt,
+      workspace_root: input.workspace_root,
+      permission_level: input.permission_level,
+      created_at: new Date().toISOString(),
+      status: 'running',
+      claude: makeInitialSide(input.claude_model),
+      codex: makeInitialSide(input.codex_model),
+    };
+    setRun(placeholder);
+    setIsRunning(true);
+    try {
+      const result = await compareApi.run({
         session_id: input.session_id,
         prompt: input.prompt,
         workspace_root: input.workspace_root,
         permission_level: input.permission_level,
-        created_at: new Date().toISOString(),
-        status: 'running',
-        claude: makeInitialSide(input.claude_model),
-        codex: makeInitialSide(input.codex_model),
-      };
-      setRun(placeholder);
-      setIsRunning(true);
-      try {
-        const result = await compareApi.run({
-          session_id: input.session_id,
-          prompt: input.prompt,
-          workspace_root: input.workspace_root,
-          permission_level: input.permission_level,
-          claude_model: input.claude_model,
-          codex_model: input.codex_model,
-        });
-        if (!result.ok) {
-          onErrorRef.current?.(result.error);
-          setIsRunning(false);
-          return null;
-        }
-        activeRunIdRef.current = result.value.run_id;
-        // run.id 갱신 — placeholder 의 빈 id 를 실제 run_id 로.
-        setRun((prev) =>
-          prev === null ? prev : { ...prev, id: result.value.run_id }
-        );
-        return result.value.run_id;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        onErrorRef.current?.(msg);
+        claude_model: input.claude_model,
+        codex_model: input.codex_model,
+      });
+      if (!result.ok) {
+        onErrorRef.current?.(result.error);
         setIsRunning(false);
         return null;
       }
-    },
-    []
-  );
+      activeRunIdRef.current = result.value.run_id;
+      // run.id 갱신 — placeholder 의 빈 id 를 실제 run_id 로.
+      setRun((prev) => (prev === null ? prev : { ...prev, id: result.value.run_id }));
+      return result.value.run_id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      onErrorRef.current?.(msg);
+      setIsRunning(false);
+      return null;
+    }
+  }, []);
 
   const cancel = useCallback(async (): Promise<void> => {
-    const compareApi =
-      typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
+    const compareApi = typeof window !== 'undefined' ? window.dreampia?.compare : undefined;
     const runId = activeRunIdRef.current;
     if (compareApi === undefined || typeof compareApi.cancel !== 'function') return;
     if (runId === null) return;

--- a/src/renderer/hooks/useKeyboardOverrides.ts
+++ b/src/renderer/hooks/useKeyboardOverrides.ts
@@ -51,23 +51,20 @@ export function useKeyboardOverrides(): UseKeyboardOverridesResult {
     };
   }, []);
 
-  const save = useCallback(
-    async (next: Record<string, string>): Promise<boolean> => {
-      // Optimistic local update — UI 가 즉시 반응.
-      setOverrides({ ...next });
-      const appApi = typeof window !== 'undefined' ? window.dreampia?.app : undefined;
-      if (appApi === undefined || typeof appApi.setKeyboardShortcuts !== 'function') {
-        return false;
-      }
-      try {
-        const result = await appApi.setKeyboardShortcuts(next);
-        return result.ok;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const save = useCallback(async (next: Record<string, string>): Promise<boolean> => {
+    // Optimistic local update — UI 가 즉시 반응.
+    setOverrides({ ...next });
+    const appApi = typeof window !== 'undefined' ? window.dreampia?.app : undefined;
+    if (appApi === undefined || typeof appApi.setKeyboardShortcuts !== 'function') {
+      return false;
+    }
+    try {
+      const result = await appApi.setKeyboardShortcuts(next);
+      return result.ok;
+    } catch {
+      return false;
+    }
+  }, []);
 
   const reset = useCallback(async (): Promise<boolean> => {
     return save({});

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -21,11 +21,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import {
-  SHORTCUT_DEFS,
-  matchesShortcut,
-  type ShortcutAction,
-} from '../keyboard/shortcuts';
+import { SHORTCUT_DEFS, matchesShortcut, type ShortcutAction } from '../keyboard/shortcuts';
 
 export interface UseKeyboardShortcutsArgs {
   /**
@@ -115,9 +111,7 @@ export function useKeyboardShortcuts(args: UseKeyboardShortcutsArgs): void {
         // [편집] 모드에서 빈 키를 저장한 경우에도 단축키가 살아 있도록.
         const rawOverride = overridesMap[def.action];
         const combo =
-          rawOverride !== undefined && rawOverride.trim().length > 0
-            ? rawOverride
-            : def.default;
+          rawOverride !== undefined && rawOverride.trim().length > 0 ? rawOverride : def.default;
         if (matchesShortcut(e, combo)) {
           e.preventDefault();
           handler();

--- a/src/renderer/hooks/useMcp.ts
+++ b/src/renderer/hooks/useMcp.ts
@@ -32,12 +32,7 @@ export interface McpServerConfigUI {
   added_at: string;
 }
 
-export type McpServerStatusUI =
-  | 'disconnected'
-  | 'connecting'
-  | 'ready'
-  | 'error'
-  | 'disabled';
+export type McpServerStatusUI = 'disconnected' | 'connecting' | 'ready' | 'error' | 'disabled';
 
 export interface McpToolInfoUI {
   name: string;

--- a/src/renderer/hooks/useOnboarding.ts
+++ b/src/renderer/hooks/useOnboarding.ts
@@ -49,10 +49,7 @@ function hasOnboardingApi(): boolean {
 }
 
 function hasResetOnboardingApi(): boolean {
-  return (
-    hasOnboardingApi() &&
-    typeof window.dreampia.app.resetOnboarding === 'function'
-  );
+  return hasOnboardingApi() && typeof window.dreampia.app.resetOnboarding === 'function';
 }
 
 export function useOnboarding(): UseOnboardingApi {

--- a/src/renderer/hooks/usePermissionRequests.ts
+++ b/src/renderer/hooks/usePermissionRequests.ts
@@ -35,11 +35,7 @@ export interface UsePermissionRequestsReturn {
    * 가장 위로 (center modal). 그 외엔 inline.
    */
   current: PermissionRequestUi | null;
-  respond: (
-    request_id: string,
-    decision: PermissionDecisionUi,
-    reason?: string
-  ) => Promise<void>;
+  respond: (request_id: string, decision: PermissionDecisionUi, reason?: string) => Promise<void>;
 }
 
 interface PermissionApi {
@@ -97,11 +93,7 @@ export function usePermissionRequests(): UsePermissionRequestsReturn {
   }, []);
 
   const respond = useCallback(
-    async (
-      request_id: string,
-      decision: PermissionDecisionUi,
-      reason?: string
-    ): Promise<void> => {
+    async (request_id: string, decision: PermissionDecisionUi, reason?: string): Promise<void> => {
       const api = apiRef.current;
       if (api === null) return;
       // Optimistic local removal — main 의 응답을 기다리지 않고 UI 정리.

--- a/src/renderer/hooks/useSessionStore.ts
+++ b/src/renderer/hooks/useSessionStore.ts
@@ -27,12 +27,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Session, SessionId, Turn } from '@/types';
-import type {
-  ConversationPatch,
-  PermissionPatch,
-  Result,
-  SessionMetaPatch,
-} from '@/main/types';
+import type { ConversationPatch, PermissionPatch, Result, SessionMetaPatch } from '@/main/types';
 
 // SessionMeta shape (kept in sync with `@/storage` and preload).
 // Defined here (not imported from `@/storage`) so the renderer never

--- a/src/renderer/hooks/useSystemTheme.ts
+++ b/src/renderer/hooks/useSystemTheme.ts
@@ -36,9 +36,7 @@ export function useSystemTheme(): SystemTheme {
     if ('addListener' in mq && typeof mq.addListener === 'function') {
       (mq as unknown as { addListener: (h: typeof handler) => void }).addListener(handler);
       return () => {
-        (mq as unknown as { removeListener: (h: typeof handler) => void }).removeListener(
-          handler
-        );
+        (mq as unknown as { removeListener: (h: typeof handler) => void }).removeListener(handler);
       };
     }
     return undefined;

--- a/src/renderer/hooks/useToasts.ts
+++ b/src/renderer/hooks/useToasts.ts
@@ -116,8 +116,7 @@ export function useToasts(): ToastsApi {
     [push]
   );
   const warning = useCallback(
-    (message: string, options?: ToastPushOptions): string =>
-      push('warning', message, options),
+    (message: string, options?: ToastPushOptions): string => push('warning', message, options),
     [push]
   );
   const info = useCallback(
@@ -125,8 +124,7 @@ export function useToasts(): ToastsApi {
     [push]
   );
   const success = useCallback(
-    (message: string, options?: ToastPushOptions): string =>
-      push('success', message, options),
+    (message: string, options?: ToastPushOptions): string => push('success', message, options),
     [push]
   );
 

--- a/src/renderer/hooks/useUsage.ts
+++ b/src/renderer/hooks/useUsage.ts
@@ -105,9 +105,11 @@ function getUsageApi(): UsageApi | null {
  * - today: 자정 (local) → 지금. daily query 는 days=1 로 매핑.
  * - 7d / 30d: 단순 N일 전 → 지금. daily query 는 days=N.
  */
-export function rangeFromPreset(
-  preset: UsageRangePreset
-): { from: string; to: string; days: number } {
+export function rangeFromPreset(preset: UsageRangePreset): {
+  from: string;
+  to: string;
+  days: number;
+} {
   const now = new Date();
   if (preset === 'today') {
     const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -146,10 +146,7 @@ export function __resetLocale(): void {
  *   - "error.xxx" 형식 (i18n key prefix) → t(value)  (한국어 fallback 자동)
  *   - 그 외 string → 원문 그대로 (이미 사람이 읽을 수 있는 메시지로 가정)
  */
-export function formatErrorDetail(
-  translate: typeof t,
-  raw: unknown
-): string {
+export function formatErrorDetail(translate: typeof t, raw: unknown): string {
   if (raw === undefined || raw === null) return translate('error.unknown');
   if (typeof raw === 'string') {
     // i18n key 같으면 t() 통과 — 누락된 키도 자체 fallback 으로 원문 반환.

--- a/src/renderer/keyboard/shortcuts.ts
+++ b/src/renderer/keyboard/shortcuts.ts
@@ -199,7 +199,10 @@ export function parseShortcut(combo: string): ParsedShortcut {
     key: '',
   };
   if (typeof combo !== 'string' || combo.length === 0) return out;
-  const parts = combo.split('+').map((p) => p.trim()).filter((p) => p.length > 0);
+  const parts = combo
+    .split('+')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
   for (const raw of parts) {
     const lower = raw.toLowerCase();
     switch (lower) {

--- a/src/renderer/mentions/resolver.ts
+++ b/src/renderer/mentions/resolver.ts
@@ -197,10 +197,7 @@ function byteLength(text: string): number {
   return Math.ceil(text.length * 1.5);
 }
 
-async function resolveFile(
-  match: MentionMatch,
-  ctx: ResolverContext
-): Promise<ResolvedMention> {
+async function resolveFile(match: MentionMatch, ctx: ResolverContext): Promise<ResolvedMention> {
   if (match.value.length === 0) {
     return { match, kind: 'error', error: '파일 경로가 비어있습니다' };
   }
@@ -222,10 +219,7 @@ async function resolveFile(
   };
 }
 
-async function resolveSession(
-  match: MentionMatch,
-  ctx: ResolverContext
-): Promise<ResolvedMention> {
+async function resolveSession(match: MentionMatch, ctx: ResolverContext): Promise<ResolvedMention> {
   if (match.value.length === 0) {
     return { match, kind: 'error', error: '세션 ID 가 비어있습니다' };
   }
@@ -381,10 +375,7 @@ export function resolveMentionsToTypedBlocks(
  * 잘라내며 (인덱스 안정성) 양옆 공백 정규화. 빈 입력이거나 멘션이 없으면
  * 입력 그대로 반환.
  */
-export function stripMentionTokens(
-  text: string,
-  mentions: ReadonlyArray<MentionMatch>
-): string {
+export function stripMentionTokens(text: string, mentions: ReadonlyArray<MentionMatch>): string {
   if (mentions.length === 0) return text;
   // 우측에서부터 잘라내면 앞쪽 인덱스가 손상되지 않는다.
   const sorted = [...mentions].sort((a, b) => b.start - a.start);

--- a/src/renderer/utils/domDump.ts
+++ b/src/renderer/utils/domDump.ts
@@ -37,10 +37,7 @@ export interface DumpOptions {
  * `Element` 가 아닌 입력 (Text node 등) → null.
  * Window/Document 미접근 환경 (vitest jsdom 환경 외) — caller 책임.
  */
-export function dumpElement(
-  el: Element,
-  options: DumpOptions = {}
-): DomDumpNode {
+export function dumpElement(el: Element, options: DumpOptions = {}): DomDumpNode {
   const maxDepth = options.maxDepth ?? 3;
   const maxText = options.maxText ?? 200;
   const includeBounds = options.includeBounds ?? true;
@@ -76,9 +73,7 @@ function dumpRec(
   // direct text only — 자식 element 의 text 제외.
   const directText = directTextOf(el).trim();
   if (directText.length > 0) {
-    node.text = directText.length > maxText
-      ? directText.slice(0, maxText) + '…'
-      : directText;
+    node.text = directText.length > maxText ? directText.slice(0, maxText) + '…' : directText;
   }
   // bounds.
   if (includeBounds && typeof el.getBoundingClientRect === 'function') {

--- a/src/renderer/utils/imageInput.ts
+++ b/src/renderer/utils/imageInput.ts
@@ -97,9 +97,7 @@ export async function readFileAsBase64(file: File): Promise<ReadFileResult> {
     binary += String.fromCharCode(bytes[i] as number);
   }
   const base64 =
-    typeof btoa === 'function'
-      ? btoa(binary)
-      : Buffer.from(binary, 'binary').toString('base64');
+    typeof btoa === 'function' ? btoa(binary) : Buffer.from(binary, 'binary').toString('base64');
   return {
     base64,
     mime: file.type,

--- a/src/renderer/utils/pdfExtract.ts
+++ b/src/renderer/utils/pdfExtract.ts
@@ -17,10 +17,7 @@ import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist/legacy/build/pdf.mj
 // pdfjs-dist 가 worker 를 별도 thread 에 로드하려 하면 vite/electron 환경에서
 // 까다롭다. main thread 동기 모드: workerSrc 를 빈 string 으로 무력화 → 자동
 // fallback (느리지만 안전).
-if (
-  typeof GlobalWorkerOptions !== 'undefined' &&
-  GlobalWorkerOptions.workerSrc.length === 0
-) {
+if (typeof GlobalWorkerOptions !== 'undefined' && GlobalWorkerOptions.workerSrc.length === 0) {
   GlobalWorkerOptions.workerSrc = '';
 }
 
@@ -80,8 +77,7 @@ export async function extractPdfText(
         }
       }
       const trimmed = text.trim();
-      const finalText =
-        trimmed.length > cap ? `${trimmed.slice(0, cap)}…` : trimmed;
+      const finalText = trimmed.length > cap ? `${trimmed.slice(0, cap)}…` : trimmed;
       pages.push({ index: i, text: finalText });
     } finally {
       // pdfjs page 객체는 cleanup 호출이 권장됨 (메모리 회수).
@@ -102,7 +98,10 @@ export async function extractPdfText(
 
   return {
     pages,
-    text: pages.map((p) => p.text).filter((t) => t.length > 0).join('\n\n'),
+    text: pages
+      .map((p) => p.text)
+      .filter((t) => t.length > 0)
+      .join('\n\n'),
     page_count: totalPages,
   };
 }
@@ -162,9 +161,7 @@ export function formatPdfExtractAsText(
     return `[PDF: ${filename}, ${result.page_count} pages — text 추출 안 됨 (이미지 PDF 일 가능성)]`;
   }
   const header = `[PDF: ${filename}, ${result.page_count} pages]`;
-  const body = nonEmpty
-    .map((p) => `--- Page ${p.index} ---\n${p.text}`)
-    .join('\n\n');
+  const body = nonEmpty.map((p) => `--- Page ${p.index} ---\n${p.text}`).join('\n\n');
   return `${header}\n\n${body}`;
 }
 

--- a/src/storage/AuditLogStore.ts
+++ b/src/storage/AuditLogStore.ts
@@ -136,20 +136,22 @@ function rowToEvent(row: AuditRow): AuditEvent {
 
 export class AuditLogStore {
   private readonly db: Database;
-  private readonly insertStmt: Statement<[
-    string,
-    string,
-    string | null,
-    string,
-    string,
-    string,
-    string,
-    string | null,
-    string | null,
-    string | null,
-    string | null,
-    string | null,
-  ]>;
+  private readonly insertStmt: Statement<
+    [
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string,
+      string,
+      string | null,
+      string | null,
+      string | null,
+      string | null,
+      string | null,
+    ]
+  >;
 
   constructor(db: Database) {
     this.db = db;

--- a/src/storage/CompareStore.ts
+++ b/src/storage/CompareStore.ts
@@ -32,12 +32,7 @@ import type { PermissionLevel } from '@/types/permission';
 
 export type CompareRunStatus = 'running' | 'completed' | 'failed';
 
-export type CompareSideStatus =
-  | 'pending'
-  | 'streaming'
-  | 'done'
-  | 'error'
-  | 'skipped';
+export type CompareSideStatus = 'pending' | 'streaming' | 'done' | 'error' | 'skipped';
 
 /**
  * 한 side (claude 또는 codex) 의 streaming 상태 + 누적 결과.
@@ -122,11 +117,7 @@ interface CompareRunRow {
 // Helpers
 // ────────────────────────────────────────────────────────────
 
-const RUN_STATUSES: ReadonlySet<CompareRunStatus> = new Set([
-  'running',
-  'completed',
-  'failed',
-]);
+const RUN_STATUSES: ReadonlySet<CompareRunStatus> = new Set(['running', 'completed', 'failed']);
 
 const SIDE_STATUSES: ReadonlySet<CompareSideStatus> = new Set([
   'pending',
@@ -149,15 +140,11 @@ function parseRunStatus(s: string): CompareRunStatus {
 
 function parseSideStatus(s: string | null): CompareSideStatus {
   if (s === null) return 'pending';
-  return SIDE_STATUSES.has(s as CompareSideStatus)
-    ? (s as CompareSideStatus)
-    : 'pending';
+  return SIDE_STATUSES.has(s as CompareSideStatus) ? (s as CompareSideStatus) : 'pending';
 }
 
 function parsePermissionLevel(s: string): PermissionLevel {
-  return PERMISSION_LEVELS.has(s as PermissionLevel)
-    ? (s as PermissionLevel)
-    : 'workspace_write';
+  return PERMISSION_LEVELS.has(s as PermissionLevel) ? (s as PermissionLevel) : 'workspace_write';
 }
 
 function rowToRun(row: CompareRunRow): CompareRun {
@@ -248,9 +235,7 @@ export class CompareStore {
        ORDER BY created_at DESC LIMIT ?`
     );
     this.deleteStmt = db.prepare(`DELETE FROM compare_runs WHERE id = ?`);
-    this.setOverallStatusStmt = db.prepare(
-      `UPDATE compare_runs SET status = ? WHERE id = ?`
-    );
+    this.setOverallStatusStmt = db.prepare(`UPDATE compare_runs SET status = ? WHERE id = ?`);
   }
 
   // ── write ─────────────────────────────────────────────────────
@@ -355,9 +340,7 @@ export class CompareStore {
     const values: unknown[] = [];
     if (patch.status !== undefined) {
       if (!SIDE_STATUSES.has(patch.status)) {
-        throw new Error(
-          `CompareStore.updateSide: invalid status '${patch.status}'`
-        );
+        throw new Error(`CompareStore.updateSide: invalid status '${patch.status}'`);
       }
       fields.push(`${side}_status = ?`);
       values.push(patch.status);
@@ -431,9 +414,7 @@ export class CompareStore {
   listBySession(sessionId: string, limit = 20): CompareRun[] {
     if (sessionId.length === 0) return [];
     const safeLimit =
-      typeof limit === 'number' && Number.isFinite(limit) && limit > 0
-        ? Math.floor(limit)
-        : 20;
+      typeof limit === 'number' && Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
     const rows = this.listStmt.all(sessionId, safeLimit) as CompareRunRow[];
     return rows.map(rowToRun);
   }

--- a/src/storage/SessionStore.ts
+++ b/src/storage/SessionStore.ts
@@ -571,7 +571,9 @@ export class SessionStore {
 
       let wal_mode: boolean | null = null;
       try {
-        const journalRows = this.db.pragma('journal_mode') as Array<{ journal_mode?: string } | string>;
+        const journalRows = this.db.pragma('journal_mode') as Array<
+          { journal_mode?: string } | string
+        >;
         const j = journalRows[0];
         const journalValue =
           typeof j === 'string'
@@ -625,9 +627,7 @@ export class SessionStore {
     const tx = this.db.transaction((s: Session): Session => {
       const resolvedWorkspaceId = this.upsertWorkspace(s);
       const next: Session =
-        resolvedWorkspaceId === s.workspace_id
-          ? s
-          : { ...s, workspace_id: resolvedWorkspaceId };
+        resolvedWorkspaceId === s.workspace_id ? s : { ...s, workspace_id: resolvedWorkspaceId };
       this.insertSessionRow(next);
       this.insertWorktrees(next);
       this.insertTurns(next);
@@ -796,9 +796,7 @@ export class SessionStore {
    *
    * UI 의 Settings > 권한 패널이 list view 로 표시 + revoke 버튼.
    */
-  listActivePermissionGrants(
-    sessionId: import('@/types').SessionId
-  ): Array<{
+  listActivePermissionGrants(sessionId: import('@/types').SessionId): Array<{
     id: string;
     capability: string;
     target_json: string;
@@ -816,14 +814,14 @@ export class SessionStore {
          ORDER BY granted_at DESC`
       )
       .all({ session_id: sessionId }) as Array<{
-        capability: string;
-        target_json: string;
-        granted_at: string;
-        granted_by: string;
-        expires_at: string | null;
-        reason: string | null;
-        scope: string;
-      }>;
+      capability: string;
+      target_json: string;
+      granted_at: string;
+      granted_by: string;
+      expires_at: string | null;
+      reason: string | null;
+      scope: string;
+    }>;
     return rows.map((r) => {
       let id = '';
       try {
@@ -1211,9 +1209,9 @@ export class SessionStore {
   private upsertWorkspace(s: Session): WorkspaceId {
     const ws = s.workspace;
     // v1.4.10 — 같은 root 가 다른 id 로 이미 존재? 그러면 그 id 채택.
-    const existing = this.db
-      .prepare('SELECT id FROM workspaces WHERE root = ?')
-      .get(ws.root) as { id: string } | undefined;
+    const existing = this.db.prepare('SELECT id FROM workspaces WHERE root = ?').get(ws.root) as
+      | { id: string }
+      | undefined;
     if (existing !== undefined && existing.id !== s.workspace_id) {
       return existing.id as WorkspaceId;
     }
@@ -2210,9 +2208,7 @@ export class SessionStore {
     const body = extractTurnText(turn.content);
     if (body.length === 0) return;
     this.db
-      .prepare(
-        `INSERT INTO turns_fts(turn_id, session_id, role, body) VALUES (?, ?, ?, ?)`
-      )
+      .prepare(`INSERT INTO turns_fts(turn_id, session_id, role, body) VALUES (?, ?, ?, ?)`)
       .run(turn.id, sessionId, turn.role, body);
   }
 

--- a/src/storage/UsageStore.ts
+++ b/src/storage/UsageStore.ts
@@ -177,11 +177,24 @@ function rowToEvent(row: UsageEventRow): UsageEvent {
 
 export class UsageStore {
   private readonly db: Database;
-  private readonly insertStmt: Statement<[
-    string, string, string, string, string,
-    number, number, number, number, number,
-    number, string, string | null, number,
-  ]>;
+  private readonly insertStmt: Statement<
+    [
+      string,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      number,
+      number,
+      string,
+      string | null,
+      number,
+    ]
+  >;
 
   constructor(db: Database) {
     this.db = db;
@@ -525,12 +538,7 @@ export class UsageStore {
  * 가능하지만 현재는 export 하지 않음 (필요해질 때 외부화).
  */
 function csvEscape(value: string): string {
-  if (
-    value.includes(',') ||
-    value.includes('"') ||
-    value.includes('\n') ||
-    value.includes('\r')
-  ) {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
     return `"${value.replace(/"/g, '""')}"`;
   }
   return value;

--- a/src/storage/metadataExtraSchema.ts
+++ b/src/storage/metadataExtraSchema.ts
@@ -84,12 +84,8 @@ const PermissionExtraSchema = z
      * v1.8.4 legacy optional. column `sessions.permission_default_level`
      * 가 단일 source. 신규 row 는 본 필드 직렬화 X.
      */
-    default_level: z
-      .enum(['read_only', 'workspace_write', 'full_access', 'custom'])
-      .optional(),
-    last_denied: z
-      .object({ capability: z.string(), ts: z.string() })
-      .optional(),
+    default_level: z.enum(['read_only', 'workspace_write', 'full_access', 'custom']).optional(),
+    last_denied: z.object({ capability: z.string(), ts: z.string() }).optional(),
     temporarily_blocked_capabilities: z.array(z.string()),
   })
   .strict();

--- a/src/storage/migrate.ts
+++ b/src/storage/migrate.ts
@@ -117,8 +117,7 @@ const MIGRATIONS: readonly Migration[] = [
   },
   {
     version: 15,
-    description:
-      'v1.8.1 — sessions.permission_default_level + plan_active promote (B-3 2단계)',
+    description: 'v1.8.1 — sessions.permission_default_level + plan_active promote (B-3 2단계)',
     up: sql015,
     down: down015,
   },
@@ -274,9 +273,7 @@ export function revertTo(db: Database, targetVersion: number): RevertToResult {
     throw new Error(`targetVersion must be a non-negative integer (got ${targetVersion})`);
   }
   if (targetVersion > current) {
-    throw new Error(
-      `Cannot revert to v${targetVersion} from v${current} (target > current).`
-    );
+    throw new Error(`Cannot revert to v${targetVersion} from v${current} (target > current).`);
   }
   if (targetVersion === current) {
     return { from: current, to: current, reverted: [] };

--- a/src/storage/workspaceBackfill.ts
+++ b/src/storage/workspaceBackfill.ts
@@ -19,10 +19,7 @@
  */
 
 import type { Database } from 'better-sqlite3';
-import {
-  isLegacyFnvWorkspaceId,
-  workspaceIdForSha256,
-} from '../types/helpers';
+import { isLegacyFnvWorkspaceId, workspaceIdForSha256 } from '../types/helpers';
 import type { WorkspaceId } from '../types';
 
 export interface BackfillResult {
@@ -63,20 +60,16 @@ export function backfillWorkspaceIdsToSha256(db: Database): BackfillResult {
   }
 
   const tx = db.transaction(() => {
-    const rows = db.prepare<unknown[], { id: string; root: string }>(
-      'SELECT id, root FROM workspaces'
-    ).all() as Array<{ id: string; root: string }>;
+    const rows = db
+      .prepare<unknown[], { id: string; root: string }>('SELECT id, root FROM workspaces')
+      .all() as Array<{ id: string; root: string }>;
     result.scanned = rows.length;
 
-    const updateWorkspace = db.prepare(
-      'UPDATE workspaces SET id = ? WHERE id = ?'
-    );
+    const updateWorkspace = db.prepare('UPDATE workspaces SET id = ? WHERE id = ?');
     const updateSessionsFk = db.prepare(
       'UPDATE sessions SET workspace_id = ? WHERE workspace_id = ?'
     );
-    const checkExistingTarget = db.prepare(
-      'SELECT 1 FROM workspaces WHERE id = ?'
-    );
+    const checkExistingTarget = db.prepare('SELECT 1 FROM workspaces WHERE id = ?');
 
     for (const row of rows) {
       // Random UUIDv7 / 이미 sha256 → skip.
@@ -156,9 +149,7 @@ export function listBackfillConflicts(db: Database): BackfillConflictRow[] {
     .prepare<unknown[], { id: string; root: string }>('SELECT id, root FROM workspaces')
     .all() as Array<{ id: string; root: string }>;
   const checkExisting = db.prepare('SELECT 1 FROM workspaces WHERE id = ?');
-  const countSessions = db.prepare(
-    'SELECT COUNT(*) as n FROM sessions WHERE workspace_id = ?'
-  );
+  const countSessions = db.prepare('SELECT COUNT(*) as n FROM sessions WHERE workspace_id = ?');
   const out: BackfillConflictRow[] = [];
   for (const row of rows) {
     if (!isLegacyFnvWorkspaceId(row.id as WorkspaceId, row.root)) continue;
@@ -190,18 +181,13 @@ export interface DeleteLegacyResult {
  *
  * caller 는 호출 전후로 in-memory cache (sessions list 등) 를 무효화.
  */
-export function deleteLegacyWorkspace(
-  db: Database,
-  legacyId: string
-): DeleteLegacyResult {
+export function deleteLegacyWorkspace(db: Database, legacyId: string): DeleteLegacyResult {
   const result: DeleteLegacyResult = {
     workspace_deleted: false,
     sessions_deleted: 0,
   };
   const tx = db.transaction(() => {
-    const sessRes = db
-      .prepare('DELETE FROM sessions WHERE workspace_id = ?')
-      .run(legacyId);
+    const sessRes = db.prepare('DELETE FROM sessions WHERE workspace_id = ?').run(legacyId);
     result.sessions_deleted = Number(sessRes.changes ?? 0);
     const wsRes = db.prepare('DELETE FROM workspaces WHERE id = ?').run(legacyId);
     result.workspace_deleted = Number(wsRes.changes ?? 0) > 0;
@@ -214,12 +200,10 @@ export function deleteLegacyWorkspace(
  * v1.4.8 — DB 의 workspaces 를 읽어 backfill 대상 통계를 반환.
  * 데이터 변경 X. 부팅 시 modal 표시 여부 결정에 사용.
  */
-export function detectLegacyWorkspaceIds(
-  db: Database
-): BackfillDetectionResult {
-  const rows = db.prepare<unknown[], { id: string; root: string }>(
-    'SELECT id, root FROM workspaces'
-  ).all() as Array<{ id: string; root: string }>;
+export function detectLegacyWorkspaceIds(db: Database): BackfillDetectionResult {
+  const rows = db
+    .prepare<unknown[], { id: string; root: string }>('SELECT id, root FROM workspaces')
+    .all() as Array<{ id: string; root: string }>;
   const total = rows.length;
   let legacy = 0;
   let conflicts = 0;

--- a/src/tools/Queue.ts
+++ b/src/tools/Queue.ts
@@ -273,9 +273,7 @@ export class ToolQueue {
     const eventName = `tool_use.${result.status}`;
     const decisionReason =
       result.status === 'success' ? 'success' : (result.error?.code ?? 'unknown');
-    const errMsg = result.error
-      ? `${result.error.code}: ${result.error.message}`
-      : undefined;
+    const errMsg = result.error ? `${result.error.code}: ${result.error.message}` : undefined;
     return {
       timestamp: result.completed_at,
       session_id: call.session_id,
@@ -314,10 +312,7 @@ export class ToolQueue {
    *   핸들러가 `event.sender.id` 를 webContentsId 로 전달. 미지정 시
    *   NO_ORIGIN(0) 버킷 사용 (테스트/프로그램적 호출용).
    */
-  async enqueue(
-    call: ToolCall,
-    origin?: { web_contents_id: number }
-  ): Promise<ToolResult> {
+  async enqueue(call: ToolCall, origin?: { web_contents_id: number }): Promise<ToolResult> {
     const webContentsId = origin?.web_contents_id ?? ToolQueue.NO_ORIGIN;
     // ── Step 1: Tool 조회 ──
     const tool = this.registry.get(call.tool_id);
@@ -385,13 +380,7 @@ export class ToolQueue {
     }
 
     // ── Step 6: 실행 ──
-    const result = await this.runTool(
-      call,
-      tool,
-      validatedInput,
-      session,
-      webContentsId
-    );
+    const result = await this.runTool(call, tool, validatedInput, session, webContentsId);
     this.emitAudit(this.resultToAuditEvent(call, result));
     return result;
   }
@@ -555,10 +544,7 @@ export class ToolQueue {
     // v1.1.1 hotfix: in-memory session grants 와 머지된 session 객체.
     // v1.1.2 hotfix: webContentsId 버킷에서 grants 조회 (sessionId X — Codex Q8).
     // Resolver 의 findActiveGrants 가 본 augmented session 의 grants 를 본다.
-    const augmentedSession = this.augmentSessionWithRuntimeGrants(
-      session,
-      webContentsId
-    );
+    const augmentedSession = this.augmentSessionWithRuntimeGrants(session, webContentsId);
 
     for (const cap of caps) {
       const target = this.resolveTarget(tool, input, cap, session);
@@ -622,12 +608,7 @@ export class ToolQueue {
         return this.decisionToError(cap, denyDecision);
       }
 
-      const decision = isAllowed(
-        cap,
-        resolved,
-        augmentedSession,
-        augmentedSession.workspace.root
-      );
+      const decision = isAllowed(cap, resolved, augmentedSession, augmentedSession.workspace.root);
 
       if (decision.allowed) continue;
 
@@ -637,10 +618,7 @@ export class ToolQueue {
       }
 
       // ── v1.1.0 SEC-2 full: requires_user_confirmation → confirmer ──
-      if (
-        decision.reason === 'requires_user_confirmation' &&
-        this.confirmer !== undefined
-      ) {
+      if (decision.reason === 'requires_user_confirmation' && this.confirmer !== undefined) {
         const userOk = await this.askConfirmation(
           tool,
           call,
@@ -720,10 +698,7 @@ export class ToolQueue {
     // downgrade. UI 가 dangerous modal 만 노출했을 때도 사용자가 IPC 직접 호출
     // 등으로 우회 시도하면 본 server-side downgrade 가 차단.
     let effectiveDecision = response.decision;
-    if (
-      highRisk &&
-      (response.decision === 'session' || response.decision === 'always')
-    ) {
+    if (highRisk && (response.decision === 'session' || response.decision === 'always')) {
       effectiveDecision = 'once';
       this.emitPermissionDecisionAudit(
         call,
@@ -806,10 +781,7 @@ export class ToolQueue {
    * 같은 webContentsId 안에서 sessionA 의 'session' grant 가 sessionB 호출에
    * 활성되는 누수 차단 — 사용자 인식 ("이 chat session 동안") 과 정합.
    */
-  private augmentSessionWithRuntimeGrants(
-    session: Session,
-    webContentsId: number
-  ): Session {
+  private augmentSessionWithRuntimeGrants(session: Session, webContentsId: number): Session {
     const bucket = this.sessionGrants.get(webContentsId) ?? [];
     if (bucket.length === 0) return session;
     const runtime = bucket.filter((g) => g.session_id === session.id);
@@ -841,9 +813,7 @@ export class ToolQueue {
    * Test inspection — 특정 webContents 의 in-memory grant 목록 (read-only).
    * v1.1.2 hotfix: 키 변경. 미지정 시 NO_ORIGIN(0) 버킷 — 테스트 호환.
    */
-  getSessionGrants(
-    webContentsId: number = ToolQueue.NO_ORIGIN
-  ): ReadonlyArray<PermissionGrant> {
+  getSessionGrants(webContentsId: number = ToolQueue.NO_ORIGIN): ReadonlyArray<PermissionGrant> {
     return this.sessionGrants.get(webContentsId) ?? [];
   }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -65,12 +65,7 @@ export { ToolRegistry } from './Registry';
 export { createContext } from './Context';
 
 // ── Queue ──
-export {
-  ToolQueue,
-  type ToolAuditEvent,
-  type ToolAuditSink,
-  type ToolQueueOptions,
-} from './Queue';
+export { ToolQueue, type ToolAuditEvent, type ToolAuditSink, type ToolQueueOptions } from './Queue';
 
 // ── Built-in tools ──
 export { ShellRunTool, type ShellRunInput, type ShellRunOutput } from './builtin/shellRun';

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -215,13 +215,7 @@ export interface ToolError {
 
 export type SideEffectKind = 'file' | 'process' | 'network';
 
-export type FileSideEffectOp =
-  | 'read'
-  | 'write'
-  | 'create'
-  | 'delete'
-  | 'rename'
-  | 'chmod';
+export type FileSideEffectOp = 'read' | 'write' | 'create' | 'delete' | 'rename' | 'chmod';
 
 export interface FileSideEffect {
   kind: 'file';

--- a/tests/main/workspaceConflict.test.ts
+++ b/tests/main/workspaceConflict.test.ts
@@ -27,37 +27,47 @@ describe('checkUserDataConflict — POSIX', () => {
   // Force POSIX 으로 보이도록 platform 검사 우회 — 본 모듈은 process.platform
   // 분기를 갖지만 path.resolve 의 구분자는 OS 의존. Linux/macOS CI 에서 직접
   // 검증.
+  //
+  // CI 안정성: `/home/u/.dreampia` 같은 path 의 일부 prefix (`/home`) 가
+  // 실제 존재 여부에 따라 realpath 가 다르게 정규화 — macOS 의 autofs 매핑
+  // (`/home` → `/System/Volumes/Data/...`) 등 환경 의존. test 는 lexical
+  // 비교만 검증하므로 모든 prefix 가 미존재인 path 를 사용 — realpath fail →
+  // 일관된 lexical fallback.
   const isWin = process.platform === 'win32';
+  const POSIX_UD = '/nonexistent-dreampia-test/u/.dreampia';
+  const WIN_UD = 'Q:\\nonexistent-dreampia-test\\u\\AppData\\Roaming\\Dreampia-Dev';
 
   it('정확 일치 → 차단', () => {
-    const root = isWin ? 'C:\\Users\\u\\AppData\\Roaming\\Dreampia-Dev' : '/home/u/.dreampia';
+    const root = isWin ? WIN_UD : POSIX_UD;
     expect(checkUserDataConflict(root, root)).not.toBeNull();
     expect(classifyUserDataConflict(root, root)).toBe('exact');
   });
 
   it('child 관계 (picked 가 userData 안) → 차단', () => {
-    const ud = isWin ? 'C:\\Users\\u\\AppData\\Roaming\\Dreampia-Dev' : '/home/u/.dreampia';
+    const ud = isWin ? WIN_UD : POSIX_UD;
     const picked = path.join(ud, 'sub', 'workspace');
     expect(classifyUserDataConflict(picked, ud)).toBe('child');
   });
 
   it('parent 관계 (picked 가 userData 의 부모) → 차단', () => {
-    const ud = isWin ? 'C:\\Users\\u\\AppData\\Roaming\\Dreampia-Dev' : '/home/u/.dreampia';
+    const ud = isWin ? WIN_UD : POSIX_UD;
     const picked = path.dirname(path.dirname(ud));
     expect(classifyUserDataConflict(picked, ud)).toBe('parent');
   });
 
   it('무관 폴더 → null', () => {
-    const ud = isWin ? 'C:\\Users\\u\\AppData\\Roaming\\Dreampia-Dev' : '/home/u/.dreampia';
-    const picked = isWin ? 'D:\\dev\\my-project' : '/home/u/projects/my-project';
+    const ud = isWin ? WIN_UD : POSIX_UD;
+    const picked = isWin
+      ? 'Q:\\nonexistent-dreampia-test\\dev\\my-project'
+      : '/nonexistent-dreampia-test/u/projects/my-project';
     expect(checkUserDataConflict(picked, ud)).toBeNull();
     expect(classifyUserDataConflict(picked, ud)).toBeNull();
   });
 
   it('sibling (같은 부모 다른 자식) → null', () => {
     const ud = isWin
-      ? 'C:\\Users\\u\\AppData\\Roaming\\Dreampia-Dev'
-      : '/home/u/Library/Application Support/Dreampia-Dev';
+      ? WIN_UD
+      : '/nonexistent-dreampia-test/u/Library/Application Support/Dreampia-Dev';
     const sibling = path.join(path.dirname(ud), 'OtherApp');
     expect(classifyUserDataConflict(sibling, ud)).toBeNull();
   });

--- a/tests/providers/api/sseParser.test.ts
+++ b/tests/providers/api/sseParser.test.ts
@@ -72,7 +72,8 @@ describe('v1.2.2 — SSE parser', () => {
 
   it('flush 가 미완성 event 강제 emit', () => {
     const parser = new SseParser();
-    [...parser.push('data: incomplete\n')];
+    // push 의 iterator 결과는 무시 — flush 가 잔여 buffer 강제 emit 검증.
+    Array.from(parser.push('data: incomplete\n'));
     const events = [...parser.flush()];
     expect(events[0]?.data).toBe('incomplete');
   });

--- a/tests/tools/Queue.high-risk.test.ts
+++ b/tests/tools/Queue.high-risk.test.ts
@@ -64,7 +64,7 @@ function makeCall(overrides: Partial<ToolCall> = {}): ToolCall {
   };
 }
 
-function makeTool(caps: Capability[]): Tool<{}, { ok: number }> {
+function makeTool(caps: Capability[]): Tool<Record<string, never>, { ok: number }> {
   return {
     id: 'mock.high-risk',
     version: '1.0.0',


### PR DESCRIPTION
## Summary

CI/CD 가 2026-05-04 이후 모든 commit 에서 fail 중 — pre-existing. 본 세션 PR #6 / #7 은 회귀 도입 X 였으나 이미 빨간 baseline 위에서 land 되어 가시화. 5 commits 으로 모든 CI gate green 회복.

## Failure clusters → fixes

| 클러스터 | Commit | 수정 |
|---------|--------|------|
| **macOS Test fail** (`workspaceConflict.test.ts:47` parent-relation) | `4422d2d` | POSIX path 를 `/nonexistent-...` prefix 로 — macOS autofs 의 `/home` 매핑 회피 |
| **Lint `no-undef`** (cost-limit-hook ctx × 6) | `ce37339` | `/* global ctx */` directive — vm.createContext sandbox global 명시 |
| **Lint `no-unused-expressions`** (sseParser:75) | `e065aed` | spread statement → `Array.from()` |
| **Lint `ban-ts-comment` × 2 + `no-unreachable`** (e2e/_drive) | `485e93b` | description 추가 + `void original;` 위치 이동 |
| **Lint `no-empty-object-type`** (Queue.high-risk:67) | `e47860d` | `{}` → `Record<string, never>` |

## 검증

- [x] `npm run lint` → 0 errors (1 pre-existing warning out of scope)
- [x] `npx tsc --noEmit` clean
- [x] 영향 영역 35 tests PASS
- [x] Full suite 188 files / 2056 tests / 0 fail

## 잔존 (out of scope, future work)

- `PermissionDangerModal.tsx:33` — react-hooks/exhaustive-deps **warning** (not error). 별 슬롯 처리.
- CI E2E + Build job 은 lint+test 통과 시 unblocked. 본 PR 후 첫 trigger.

## Test plan

- [x] Local Windows: 2056/2056 PASS
- [ ] CI macos-latest: workspaceConflict 통과 예상
- [ ] CI ubuntu-latest: 동일 (cancelled 원인 fail-fast 해소)
- [ ] CI windows-latest: 동일
- [ ] CI Lint: 4 cluster 모두 해소 → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)