### PR TITLE
fix(e2e): drive14/15/16 5 specs 회복 (v1.1.5 Real CLI integration)

### DIFF
--- a/e2e/_drive14.spec.ts
+++ b/e2e/_drive14.spec.ts
@@ -29,6 +29,17 @@ test.describe('drive14 — Claude CLI tool_use round-trip (VCR)', () => {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 — chat-input 노출 prerequisite (drive3 와 동일 패턴).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      // 모델 설정 — 본 fixture 는 Claude argv 기반. App.tsx 기본 `gpt-5.5` 는
+      // codex CLI argv 로 라우팅되어 fake CLI 검증 실패. /model 슬래시로 명시.
+      // Slash popover 가 열린 상태로 Enter 시 handlePickCommand 가 hasArgs=true
+      // /model 트리거를 다시 채워 arg 가 사라짐 (UX 버그). Escape 로 popover
+      // 먼저 dismiss 한 후 Enter.
+      const _modelInput = window.getByTestId('chat-input');
+      await _modelInput.fill('/model claude-sonnet-4-6');
+      await _modelInput.press('Escape');
+      await _modelInput.press('Enter');
 
       // 2. 채팅 입력. fixture 의 prompt_last 와 정확히 일치해야 fake CLI 가
       //    argv-last 검증 통과. testid 는 ChatInput 의 'chat-input' (textarea).
@@ -71,6 +82,17 @@ test.describe('drive14 — Claude CLI tool_use round-trip (VCR)', () => {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 — chat-input 노출 prerequisite (drive3 와 동일 패턴).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      // 모델 설정 — 본 fixture 는 Claude argv 기반. App.tsx 기본 `gpt-5.5` 는
+      // codex CLI argv 로 라우팅되어 fake CLI 검증 실패. /model 슬래시로 명시.
+      // Slash popover 가 열린 상태로 Enter 시 handlePickCommand 가 hasArgs=true
+      // /model 트리거를 다시 채워 arg 가 사라짐 (UX 버그). Escape 로 popover
+      // 먼저 dismiss 한 후 Enter.
+      const _modelInput = window.getByTestId('chat-input');
+      await _modelInput.fill('/model claude-sonnet-4-6');
+      await _modelInput.press('Escape');
+      await _modelInput.press('Enter');
       const composer = window.getByTestId('chat-input');
       await composer.fill('현재 디렉토리 파일 목록 보여줘');
       await composer.press('Enter');
@@ -93,6 +115,17 @@ test.describe('drive14 — Claude CLI tool_use round-trip (VCR)', () => {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 — chat-input 노출 prerequisite (drive3 와 동일 패턴).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      // 모델 설정 — 본 fixture 는 Claude argv 기반. App.tsx 기본 `gpt-5.5` 는
+      // codex CLI argv 로 라우팅되어 fake CLI 검증 실패. /model 슬래시로 명시.
+      // Slash popover 가 열린 상태로 Enter 시 handlePickCommand 가 hasArgs=true
+      // /model 트리거를 다시 채워 arg 가 사라짐 (UX 버그). Escape 로 popover
+      // 먼저 dismiss 한 후 Enter.
+      const _modelInput = window.getByTestId('chat-input');
+      await _modelInput.fill('/model claude-sonnet-4-6');
+      await _modelInput.press('Escape');
+      await _modelInput.press('Enter');
       const composer = window.getByTestId('chat-input');
       await composer.fill('현재 디렉토리 파일 목록 보여줘');
       await composer.press('Enter');
@@ -150,6 +183,17 @@ test.describe('drive14 — Claude CLI tool_use round-trip (VCR)', () => {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 — chat-input 노출 prerequisite (drive3 와 동일 패턴).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      // 모델 설정 — 본 fixture 는 Claude argv 기반. App.tsx 기본 `gpt-5.5` 는
+      // codex CLI argv 로 라우팅되어 fake CLI 검증 실패. /model 슬래시로 명시.
+      // Slash popover 가 열린 상태로 Enter 시 handlePickCommand 가 hasArgs=true
+      // /model 트리거를 다시 채워 arg 가 사라짐 (UX 버그). Escape 로 popover
+      // 먼저 dismiss 한 후 Enter.
+      const _modelInput = window.getByTestId('chat-input');
+      await _modelInput.fill('/model claude-sonnet-4-6');
+      await _modelInput.press('Escape');
+      await _modelInput.press('Enter');
       // detect-cli 가 fire 된 후 badge 가 마운트되거나 안 될 수 있음 (CLI 미감지
       // 면 'No CLI' badge — 그것도 mock 아님). 충분 대기 후 확인.
       await window.waitForTimeout(2_000);

--- a/e2e/_drive15.spec.ts
+++ b/e2e/_drive15.spec.ts
@@ -27,6 +27,12 @@ test.describe('drive15 — KR cwd 와 함께 tool_use round-trip', () => {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 + Claude 모델 설정 (drive14 와 동일 — fixture 가 Claude argv 기반).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      const _modelInput15 = window.getByTestId('chat-input');
+      await _modelInput15.fill('/model claude-sonnet-4-6');
+      await _modelInput15.press('Escape');
+      await _modelInput15.press('Enter');
 
       const composer = window.getByTestId('chat-input');
       await composer.fill('현재 디렉토리 파일 목록 보여줘');

--- a/e2e/_drive16.spec.ts
+++ b/e2e/_drive16.spec.ts
@@ -26,6 +26,12 @@ function test_exitNonZero(): void {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 + Claude 모델 설정 (drive14 와 동일 — fixture 가 Claude argv 기반).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      const _modelInput16 = window.getByTestId('chat-input');
+      await _modelInput16.fill('/model claude-sonnet-4-6');
+      await _modelInput16.press('Escape');
+      await _modelInput16.press('Enter');
       const composer = window.getByTestId('chat-input');
       await composer.fill('실패 케이스');
       await composer.press('Enter');
@@ -53,6 +59,12 @@ function test_stderrError(): void {
       await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
         timeout: 15_000,
       });
+      // 새 세션 시작 + Claude 모델 설정 (drive14 와 동일 — fixture 가 Claude argv 기반).
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      const _modelInput16 = window.getByTestId('chat-input');
+      await _modelInput16.fill('/model claude-sonnet-4-6');
+      await _modelInput16.press('Escape');
+      await _modelInput16.press('Enter');
       const composer = window.getByTestId('chat-input');
       await composer.fill('stderr 에러');
       await composer.press('Enter');

--- a/e2e/fixtures-vcr.ts
+++ b/e2e/fixtures-vcr.ts
@@ -107,6 +107,10 @@ export function makeVcrTest(fixtureRelPath: string, options: MakeVcrTestOptions 
             onboarding_completed: true,
             workspace_root: workspaceDir,
             workspace_name: basename(workspaceDir),
+            // E2E v1.1.5 — drive14/15/16 spec 들이 PermissionApprovalCard
+            // 표시를 검증하므로 prompt 발생 강제. default workspace_write 는
+            // shell.run 의 LOCAL_EXECUTE 를 auto-allow → card 안 뜸.
+            default_permission_level: 'read_only',
           },
           null,
           2

--- a/src/renderer/commands/registry.ts
+++ b/src/renderer/commands/registry.ts
@@ -108,7 +108,12 @@ export const SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [
  * 새 모델이 출시되면 여기와 `src/providers/pricing.ts` 양쪽에 추가.
  */
 export const KNOWN_MODELS: ReadonlyArray<string> = [
-  // Claude
+  // Claude (4.x — current)
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  // Claude (3.x — legacy)
   'claude-3-5-sonnet-20241022',
   'claude-3-5-sonnet',
   'claude-3-5-haiku',

--- a/tests/fixtures/cli-vcr/claude/tool-use-roundtrip.json
+++ b/tests/fixtures/cli-vcr/claude/tool-use-roundtrip.json
@@ -30,7 +30,7 @@
     },
     {
       "delay_ms": 15,
-      "data": "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_vcr_001\",\"name\":\"shell_run\",\"input\":{\"command\":\"ls\"}}],\"usage\":{\"input_tokens\":12,\"output_tokens\":18,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n"
+      "data": "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_vcr_001\",\"name\":\"shell_run\",\"input\":{\"cmd\":\"ls\"}}],\"usage\":{\"input_tokens\":12,\"output_tokens\":18,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n"
     },
     {
       "delay_ms": 5,

--- a/tests/providers/cli/fakeCliReplay.test.ts
+++ b/tests/providers/cli/fakeCliReplay.test.ts
@@ -178,7 +178,7 @@ describe('v1.1.5 — fake CLI replay (Tier 2 integration)', () => {
         if (tc?.type === 'tool_call_complete') {
           expect(tc.tool_call.tool_id).toBe('shell.run');
           expect(tc.tool_call.id).toBe('toolu_vcr_001');
-          expect(tc.tool_call.input).toEqual({ command: 'ls' });
+          expect(tc.tool_call.input).toEqual({ cmd: 'ls' });
         }
 
         // 에러 event 없음.


### PR DESCRIPTION
## Summary

PR #9 머지 후 잔존 11 fail 중 drive14/15/16 영역 5 specs 회복.

baseline: 88 passed / 11 failed → **95 passed / 6 failed / 1 skipped**.

## 회복된 specs (5)

| Spec | 이전 | 지금 |
|------|------|------|
| drive14-1 (PermissionApprovalCard) | ❌ | ✅ |
| drive14-2 (ToolCallCard 노출) | ❌ | ✅ |
| drive15-1 (KR cwd tool_use) | ❌ | ✅ |
| drive16-1 (exit !== 0) | ❌ | ✅ |
| drive16-2 (stderr 401) | ❌ | ✅ |

## 적용된 5 fix

각 spec/fixture/code 의 layered drift 정합:

1. **새 채팅 click step** — chat-input testid prerequisite (drive3 패턴)
2. **fixture `cmd` 필드** — ShellRunInputSchema 매칭
3. **KNOWN_MODELS Claude 4.x 추가** — claude-sonnet-4-6 등
4. **/model + Escape + Enter** — slash popover hasArgs UX 회피
5. **default_permission_level: read_only** — PermissionApprovalCard 표시 강제

## 잔존 6 fails (별 슬롯)

- drive14-3 (SessionStore 영속)
- drive18-1, 2, 3 (a11y axe-core)
- drive6 (preview toggle)
- chat-mention

## Test plan

- [x] Local E2E full suite 95/6/1 (이전 88/11/3)
- [x] vitest baseline 무회귀 (KNOWN_MODELS 확장은 backward-compatible)
- [ ] CI 모든 9 체크 green 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)