### PR TITLE
feat(cli): A3 — CliProvider auto timeout (v1.9.0 Phase A)

### DIFF
--- a/docs/adr/0001-cli-provider-timeout.md
+++ b/docs/adr/0001-cli-provider-timeout.md
@@ -1,0 +1,97 @@
+# ADR-0001 — CliProvider 자동 timeout (`timeout_ms`)
+
+> **Status**: Accepted
+> **Date**: 2026-05-08
+> **Phase**: A3 (v1.9.0 hotfix sweep)
+> **Authors**: 사용자 결정 + Claude Code (Opus 4.7)
+
+---
+
+## Context
+
+`CliProvider` 는 Claude / Codex CLI subprocess 를 spawn 해 streaming 응답을
+중계한다. 기존에는 mid-stream 취소가 외부 `AbortSignal` 에 한정됐다 — 즉
+사용자가 명시적으로 stop 버튼을 눌렀거나 IPC 가 cancel 신호를 보낸 경우만.
+
+**Gap (v1.1.4 postmortem 의 잔존 항목)**: CLI 가 hang / 무한 응답 중일 때
+사용자 개입 없이 자동 종료하는 메커니즘이 부재했다. drive16-3 abort
+unit cover 는 user-cancel 경로만 검증할 뿐, "CLI 가 응답을 못 받아 영원히
+대기" 시나리오는 미보장 — 메인 process / IPC 큐 / UI streaming-cursor 가
+영구히 stuck 되는 risk 가 있었다.
+
+## Decision
+
+`CliProviderOptions` 에 `timeout_ms?: number` 필드를 추가한다.
+
+- **default**: `undefined` (timeout 없음, opt-in)
+- **set 시**: spawn 직후 `setTimeout(onTimeout, timeout_ms)` 설치. fire 시
+  - `errorState.message = 'CLI timeout exceeded (Xms)'` 로 표면화
+  - `child.kill('SIGTERM')` 으로 subprocess 종료
+  - 기존 drain loop 가 종료되며 `error` StreamEvent emit 후 `return`
+  - close handler / error handler / finally 모두 `clearTimeout` defensive 처리
+
+**Production wire**:
+- `auto.ts` 가 `parseTimeoutMsEnv()` 헬퍼로 `DREAMPIA_CLI_TIMEOUT_MS` env 읽음
+- 미설정 → undefined (기본 무제한)
+- 양수 정수 → ms 적용
+- `cliOverride` (test/e2e replay) 와 `makeCliProvider` (production CLI) 두
+  경로 모두 동일하게 wire — 정책 일관성
+
+## Alternatives Considered
+
+| 대안 | 검토 결과 |
+|------|-----------|
+| **production default 60s** | 기각 — backward-compat 깨짐, opt-in 으로 callsite 가 의도 명시 |
+| **production default 120s** | 기각 — 동일 |
+| **AbortSignal 만으로 외부 timeout 처리** | 기각 — 호출자마다 timer 중복 구현, leak risk |
+| **별도 `timeoutController` 생성 + `signal` chain** | 기각 — 단순 SIGTERM 으로 충분, AbortSignal.any() 의존 회피 |
+| **프로세스 polling** | 기각 — 복잡도 증가, 정확도 낮음 |
+
+## Semantics — `signal` (user-cancel) vs `timeout_ms`
+
+| | `signal.abort()` | `timeout_ms` 경과 |
+|---|---|---|
+| `aborted` flag | true | false |
+| `timedOut` flag | false | true |
+| `errorState.message` | null | `"CLI timeout exceeded (Xms)"` |
+| `error` StreamEvent emit | 안 함 (silent return) | emit |
+| close handler exit-code 합성 | skip (`!aborted`) | skip (`!timedOut`) |
+| UI 표면 | `cancelled` | `failed` (error 표시) |
+
+분리된 의미 — user 가 의도적으로 cancel 한 거라면 silent, hang 으로 인한
+auto-kill 이라면 명시적 error 표면화.
+
+## Consequences
+
+### Positive
+- 개별 hang 이 main process 전체를 stuck 시키지 않음
+- 호출자가 `timeout_ms` 만 명시하면 timer 관리 책임 위임 가능
+- e2e drive16-3 (timeout) 회귀 lock 가능 — `slow-stream.json` fixture 재사용
+
+### Negative
+- 사용자가 정상이지만 느린 응답 (large reasoning) 을 timeout 으로 잘라낼 risk
+  → mitigation: opt-in 이라 caller 가 의식적으로 값 설정해야 함
+- `DREAMPIA_CLI_TIMEOUT_MS` env 가 모든 CliProvider 인스턴스에 일률 적용 →
+  세션별 override 는 미지원. 추후 settings UI / per-call option 으로 확장 가능
+
+### Future Work
+- `settings.json` 의 `cli_timeout_ms` 필드 + Settings UI (별도 슬롯 — 본 ADR 범위 밖)
+- per-model default (e.g. opus 는 더 길게) — 필요 시 추가
+
+## Test Coverage
+
+| Test | Layer | Fixture |
+|------|-------|---------|
+| `drive16-4: timeout_ms 경과 시 error event` | vitest (Tier 2) | `claude/slow-stream.json` |
+| `drive16-4 regression: 미설정 시 message_complete` | vitest (Tier 2) | `claude/slow-stream.json` |
+| `drive16-3: timeout_ms env override` | e2e (Playwright) | `claude/slow-stream.json` + `DREAMPIA_CLI_TIMEOUT_MS=300` |
+
+---
+
+## References
+
+- 코드: `src/providers/cli/CliProvider.ts:39-...` (옵션 정의)
+- 코드: `src/providers/cli/CliProvider.ts:onTimeout` (timer 로직)
+- 코드: `src/providers/auto.ts:parseTimeoutMsEnv` (env 파싱)
+- Roadmap: `docs/v2.x-roadmap.md` (Phase A — A3)
+- Prior: `docs/v1.x-completion-audit.md` (drive16-3 abort)

--- a/docs/v2.x-roadmap.md
+++ b/docs/v2.x-roadmap.md
@@ -102,11 +102,13 @@
 
 ## Open Questions
 
-- [ ] semver: Phase A = v1.9.0 / Phase B = v2.0.0 분리 vs A+B 묶어 v2.0.0 — Plugin API breaking 여부에 의존
-- [ ] `MetadataExtra` legacy optional 두 필드 strict removal 시점 — down-grade 지원 범위 결정
-- [ ] F4 격리 mechanism — utility_process / worker_threads / VM — DX 영향
-- [ ] DREAMPIA_VCR_MODE production runtime 강제 정책 — startup fail vs warning vs telemetry only
-- [ ] Phase D 새 기능 후보 우선순위 — 시장/UX 가치 평가 필요 (analyst 권한 외)
+> **Resolved 2026-05-08** — 사용자 결정 (이 세션):
+
+- [x] **semver**: Phase A → **v1.9.0** / Phase B → **v2.0.0** 분리 (A 는 non-breaking sweep, B 는 Plugin API breaking)
+- [x] **`MetadataExtra` legacy optional** strict removal: **v2.0.0** (Phase B breaking 흐름에 묶음)
+- [x] **F4 격리 mechanism**: **utility_process** (Electron-native, V8 isolate, 22+ 안정 API)
+- [x] **DREAMPIA_VCR_MODE production**: **startup fail** (test fixture prod 누출 차단 — 가장 안전)
+- [x] **Phase D 새 기능 우선순위**: **Chat virtualization 최우선** (v1.6.23+ 후보, 장기 세션 perf)
 
 ---
 

--- a/e2e/_drive16.spec.ts
+++ b/e2e/_drive16.spec.ts
@@ -2,20 +2,23 @@
  * drive16 — Real CLI integration e2e: failure modes (v1.1.9 / Codex Q9 권고).
  *
  * Spec: docs/v1.x-roadmap.md (v1.1.4 Real CLI integration e2e), Codex Q9 picking 5.
+ * v1.9.0 (A3): drive16-3 timeout 추가 — `docs/adr/0001-cli-provider-timeout.md`.
  *
  * 시나리오:
  *   - 16-1: fake CLI exit !=0 → ChatPanel 에 error message 표시.
  *   - 16-2: fake CLI stderr 에 error keyword → 마찬가지 error 표시.
+ *   - 16-3: CliProvider timeout_ms 경과 → SIGTERM + error event → assistant 종료.
  *
- * 본 spec 은 chat 입력 → fake CLI 가 의도적으로 실패 → renderer 가 error UI
- * 를 보여주는지 회귀 lock. CliProvider 의 fail-closed 정책이 production code
- * path 에서도 정상 작동하는지 검증.
+ * 본 spec 은 chat 입력 → fake CLI 가 의도적으로 실패 / hang → renderer 가
+ * error UI 를 보여주는지 회귀 lock. CliProvider 의 fail-closed 정책이
+ * production code path 에서도 정상 작동하는지 검증.
  */
 
 import { makeVcrTest, expect } from './fixtures-vcr';
 
 test_exitNonZero();
 test_stderrError();
+test_timeout();
 
 function test_exitNonZero(): void {
   const test = makeVcrTest('claude/failure-exit-nonzero.json');
@@ -72,6 +75,39 @@ function test_stderrError(): void {
       const assistantTurn = window.getByTestId('turn-assistant').first();
       await expect(assistantTurn).toBeVisible({ timeout: 20_000 });
 
+      const cursor = window.getByTestId('streaming-cursor');
+      await expect(cursor).not.toBeVisible({ timeout: 15_000 });
+    });
+  });
+}
+
+function test_timeout(): void {
+  // v1.9.0 (A3): slow-stream.json 의 3rd chunk 가 855ms 에 도착 — timeout_ms=300
+  // 이면 first/second chunk 통과 후 third 도착 전 timeout fire → SIGTERM.
+  // ADR: docs/adr/0001-cli-provider-timeout.md.
+  const test = makeVcrTest('claude/slow-stream.json', { cliTimeoutMs: 300 });
+  test.describe('drive16 — failure: CliProvider timeout_ms', () => {
+    test('16-3 — DREAMPIA_CLI_TIMEOUT_MS=300 + slow fixture → assistant turn 종료', async ({
+      window,
+    }) => {
+      await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
+        timeout: 15_000,
+      });
+      await window.getByRole('button', { name: '새 채팅', exact: false }).first().click();
+      const _modelInput16 = window.getByTestId('chat-input');
+      await _modelInput16.fill('/model claude-sonnet-4-6');
+      await _modelInput16.press('Escape');
+      await _modelInput16.press('Enter');
+      const composer = window.getByTestId('chat-input');
+      // slow-stream.json 의 argv_assert.prompt_last 에 정확히 매칭.
+      await composer.fill('긴응답');
+      await composer.press('Enter');
+
+      const assistantTurn = window.getByTestId('turn-assistant').first();
+      await expect(assistantTurn).toBeVisible({ timeout: 20_000 });
+
+      // timeout 으로 SIGTERM → CliProvider 가 error event emit → streaming-cursor
+      // 사라짐 (drive16-1, 16-2 의 fail-closed 패턴과 동일).
       const cursor = window.getByTestId('streaming-cursor');
       await expect(cursor).not.toBeVisible({ timeout: 15_000 });
     });

--- a/e2e/fixtures-vcr.ts
+++ b/e2e/fixtures-vcr.ts
@@ -49,6 +49,12 @@ export interface MakeVcrTestOptions {
    * lock — Codex Q5 picking 의 한국어 폴더 처리 검증.
    */
   koreanWorkspace?: boolean;
+  /**
+   * v1.9.0 (A3 / drive16-3): `DREAMPIA_CLI_TIMEOUT_MS` 주입. set 시
+   * CliProvider 가 spawn 후 N ms 경과 시 SIGTERM + error event.
+   * undefined → env 미설정 (timeout 없음).
+   */
+  cliTimeoutMs?: number;
 }
 
 /**
@@ -132,6 +138,10 @@ export function makeVcrTest(fixtureRelPath: string, options: MakeVcrTestOptions 
           DREAMPIA_CLI_COMMAND: process.execPath,
           DREAMPIA_CLI_PREARGS: FAKE_CLI,
           DREAMPIA_VCR_FIXTURE: vcrFixture,
+          // v1.9.0 (A3): drive16-3 timeout spec 만 set. 그 외 spec 은 undefined.
+          ...(options.cliTimeoutMs !== undefined && {
+            DREAMPIA_CLI_TIMEOUT_MS: String(options.cliTimeoutMs),
+          }),
         },
       });
 

--- a/src/providers/auto.ts
+++ b/src/providers/auto.ts
@@ -93,6 +93,7 @@ export async function getDefaultProvider(
     const lower = model.toLowerCase();
     const codexFamily = ['gpt-', 'o1-', 'o3-', 'codex-'].some((p) => lower.startsWith(p));
     const provider: 'claude' | 'codex' = codexFamily ? 'codex' : 'claude';
+    const timeoutMs = parseTimeoutMsEnv();
     return {
       provider: new CliProvider({
         binaryPath: cliOverride.command,
@@ -101,6 +102,7 @@ export async function getDefaultProvider(
         ...(signal !== undefined && { signal }),
         ...(cwd !== undefined && { cwd }),
         ...(permissionLevel !== undefined && { permissionLevel }),
+        ...(timeoutMs !== undefined && { timeout_ms: timeoutMs }),
         preArgs: cliOverride.pre_args,
       }),
       source: provider === 'claude' ? 'claude-cli' : 'codex-cli',
@@ -251,6 +253,7 @@ function makeCliProvider(
   cwd?: string,
   permissionLevel?: PermissionLevel
 ): CliProvider {
+  const timeoutMs = parseTimeoutMsEnv();
   return new CliProvider({
     binaryPath: info.path,
     provider,
@@ -258,5 +261,24 @@ function makeCliProvider(
     ...(signal !== undefined && { signal }),
     ...(cwd !== undefined && { cwd }),
     ...(permissionLevel !== undefined && { permissionLevel }),
+    ...(timeoutMs !== undefined && { timeout_ms: timeoutMs }),
   });
+}
+
+/**
+ * v1.9.0 (A3) — `DREAMPIA_CLI_TIMEOUT_MS` env 파싱.
+ *
+ * - 미설정 / 빈 문자열 / parse 실패 / `<= 0` → `undefined` (timeout 없음, opt-in)
+ * - 양수 정수 → 그대로 ms 로 적용
+ *
+ * Spec: docs/adr/0001-cli-provider-timeout.md
+ *
+ * Future: settings.json `cli_timeout_ms` 가 env 보다 우선하도록 확장.
+ */
+function parseTimeoutMsEnv(): number | undefined {
+  const raw = process.env.DREAMPIA_CLI_TIMEOUT_MS;
+  if (raw === undefined || raw.length === 0) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
 }

--- a/src/providers/cli/CliProvider.ts
+++ b/src/providers/cli/CliProvider.ts
@@ -59,6 +59,18 @@ export interface CliProviderOptions {
   /** Mid-stream 취소용 (MAIN process 가 IPC 'ai/stop-stream' 에서 사용). */
   signal?: AbortSignal;
   /**
+   * v1.9.0 (A3) — 자동 timeout (ms). Set 되면 spawn 후 timeout_ms 경과 시
+   * SIGTERM kill + `error` StreamEvent emit. `undefined` = 무제한 (backward-compat).
+   *
+   * `signal` (user-cancel) 과 분리된 의미:
+   *   signal abort → silent return (UI 가 'cancelled' 표시)
+   *   timeout      → `error` event ("CLI timeout exceeded (Xms)") + return
+   *
+   * Production wire: auto.ts 가 DREAMPIA_CLI_TIMEOUT_MS env 로 override 가능.
+   * Spec: docs/adr/0001-cli-provider-timeout.md
+   */
+  timeout_ms?: number;
+  /**
    * Session permission level — provider CLI 의 sandbox / tool-policy 옵션으로 매핑된다.
    *
    * Codex: '--sandbox <mode>' 로 전달.
@@ -160,6 +172,10 @@ export class CliProvider implements StreamingProvider {
     const errorState: { message: string | null } = { message: null };
     let receivedComplete = false;
     let aborted = false;
+    // v1.9.0 (A3) — auto timeout. aborted 와 분리된 flag — error event emit
+    // 여부가 다르고, close handler 의 exit-code 합성 분기에서 제외 대상.
+    let timedOut = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
     const wakeUp = (): void => {
       const fn = resolveNext;
@@ -212,6 +228,25 @@ export class CliProvider implements StreamingProvider {
       }
     }
 
+    // v1.9.0 (A3) — timeout_ms 설정 시 자동 SIGTERM + error event.
+    // signal abort 와 달리 errorState.message 를 set 해 emit 경로를 탄다.
+    const onTimeout = (): void => {
+      timedOut = true;
+      const ms = this.opts.timeout_ms;
+      errorState.message =
+        `${errorState.message ?? ''}CLI timeout exceeded (${ms}ms)`.trim();
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // ignore — child 가 이미 종료됐을 수 있음.
+      }
+      ended = true;
+      wakeUp();
+    };
+    if (this.opts.timeout_ms !== undefined && this.opts.timeout_ms > 0) {
+      timeoutHandle = setTimeout(onTimeout, this.opts.timeout_ms);
+    }
+
     child.stdout?.on('data', (chunk: Buffer) => {
       const lines = parser.push(chunk.toString());
       for (const parsed of lines) {
@@ -232,19 +267,30 @@ export class CliProvider implements StreamingProvider {
     });
 
     child.on('error', (err) => {
+      // v1.9.0 (A3): child 에러로 종료될 때도 timer 누수 방지.
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
       errorState.message = err.message;
       ended = true;
       wakeUp();
     });
 
     child.on('close', (code) => {
+      // child 가 자연 종료했으니 pending timeout 정리.
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
       // 마지막 라인 flush
       for (const parsed of parser.flush()) {
         for (const ev of this.opts.translate(parsed, ctx)) {
           enqueue(ev);
         }
       }
-      if (code !== 0 && code !== null && !aborted) {
+      // v1.9.0 (A3): timedOut 도 SIGTERM 으로 종료시킨 거라 exit-code 메시지 합성 X.
+      if (code !== 0 && code !== null && !aborted && !timedOut) {
         errorState.message = `${errorState.message ?? ''} (exit code ${code})`.trim();
       }
       ended = true;
@@ -266,6 +312,11 @@ export class CliProvider implements StreamingProvider {
     } finally {
       if (this.opts.signal !== undefined) {
         this.opts.signal.removeEventListener('abort', onAbort);
+      }
+      // v1.9.0 (A3): 어떤 경로로 빠져나오든 timer leak 방지.
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
       }
     }
 

--- a/src/providers/cli/CliProvider.ts
+++ b/src/providers/cli/CliProvider.ts
@@ -233,8 +233,7 @@ export class CliProvider implements StreamingProvider {
     const onTimeout = (): void => {
       timedOut = true;
       const ms = this.opts.timeout_ms;
-      errorState.message =
-        `${errorState.message ?? ''}CLI timeout exceeded (${ms}ms)`.trim();
+      errorState.message = `${errorState.message ?? ''}CLI timeout exceeded (${ms}ms)`.trim();
       try {
         child.kill('SIGTERM');
       } catch {

--- a/tests/providers/cli/fakeCliReplay.test.ts
+++ b/tests/providers/cli/fakeCliReplay.test.ts
@@ -344,8 +344,7 @@ describe('v1.1.5 — fake CLI replay (Tier 2 integration)', () => {
 
   // v1.1.4-hotfix-1 — drive16-3: cancel mid-stream → CliProvider 가 SIGTERM
   // 으로 fake CLI 종료. 첫 chunk 만 받고 abort → message_complete 없음 +
-  // 부분 events 만 도착. (architect 권고: timeout 시나리오는 CliProvider 자체
-  // timeout option 부재로 e2e 미작성, abort 단위 cover 로 충분.)
+  // 부분 events 만 도착. (v1.9.0 / A3: 자동 timeout 은 별도 it 케이스로 분리.)
   it(
     'drive16-3: cancel mid-stream → SIGTERM transmitted, no message_complete',
     async () => {
@@ -381,6 +380,95 @@ describe('v1.1.5 — fake CLI replay (Tier 2 integration)', () => {
 
         // 일부 events 는 도착했어야 함 (적어도 message_start).
         expect(events.length).toBeGreaterThan(0);
+      } finally {
+        if (originalEnv === undefined) delete process.env.DREAMPIA_VCR_FIXTURE;
+        else process.env.DREAMPIA_VCR_FIXTURE = originalEnv;
+      }
+    },
+    20_000
+  );
+
+  // v1.9.0 (A3) — drive16-4: timeout_ms 경과 시 SIGTERM + error event emit.
+  // 사용자-cancel (signal) 과 분리: timeout 은 명시적 error 메시지 표면화한다.
+  // slow-stream.json 의 3rd chunk 가 855ms 에 도착하므로 timeout_ms=300 이면
+  // 첫번째 / 두번째 chunk 는 통과, 3rd chunk 도착 전 timeout fire.
+  it(
+    'drive16-4: timeout_ms 경과 시 error event + no message_complete',
+    async () => {
+      const provider = new CliProvider({
+        binaryPath: execPath,
+        provider: 'claude',
+        translate: translateClaudeJsonl,
+        preArgs: [FAKE_CLI],
+        timeout_ms: 300,
+      });
+
+      const originalEnv = process.env.DREAMPIA_VCR_FIXTURE;
+      process.env.DREAMPIA_VCR_FIXTURE = FIXTURE_SLOW_STREAM;
+      try {
+        const events: StreamEvent[] = [];
+        const iterator = provider.stream({
+          turns: [makeUserTurn('긴응답')],
+          model: 'claude-sonnet-4-6',
+        });
+        for await (const ev of iterator) {
+          events.push(ev);
+        }
+
+        // 핵심 invariant 1: error event 가 timeout 메시지로 표면화 됨.
+        const errorEvents = events.filter((e) => e.type === 'error');
+        expect(errorEvents.length).toBe(1);
+        const errorEvent = errorEvents[0];
+        if (errorEvent !== undefined && errorEvent.type === 'error') {
+          expect(errorEvent.error).toMatch(/CLI timeout exceeded \(300ms\)/);
+        }
+
+        // 핵심 invariant 2: message_complete 없음 (timeout 됐으니).
+        const completes = events.filter((e) => e.type === 'message_complete');
+        expect(completes.length).toBe(0);
+
+        // 핵심 invariant 3: timeout 이전 chunk 들은 도착 (message_start 최소).
+        expect(events.length).toBeGreaterThan(1);
+      } finally {
+        if (originalEnv === undefined) delete process.env.DREAMPIA_VCR_FIXTURE;
+        else process.env.DREAMPIA_VCR_FIXTURE = originalEnv;
+      }
+    },
+    20_000
+  );
+
+  // v1.9.0 (A3) — timeout_ms=undefined 시 기존 happy path 가 그대로 흐른다 (regression guard).
+  it(
+    'drive16-4 regression: timeout_ms 미설정 시 message_complete 정상 도달',
+    async () => {
+      const provider = new CliProvider({
+        binaryPath: execPath,
+        provider: 'claude',
+        translate: translateClaudeJsonl,
+        preArgs: [FAKE_CLI],
+        // timeout_ms 의도적 미지정 (opt-in default).
+      });
+
+      const originalEnv = process.env.DREAMPIA_VCR_FIXTURE;
+      process.env.DREAMPIA_VCR_FIXTURE = FIXTURE_SLOW_STREAM;
+      try {
+        const events: StreamEvent[] = [];
+        for await (const ev of provider.stream({
+          turns: [makeUserTurn('긴응답')],
+          model: 'claude-sonnet-4-6',
+        })) {
+          events.push(ev);
+        }
+
+        // timeout 없으면 모든 chunk + message_complete 도달.
+        const completes = events.filter((e) => e.type === 'message_complete');
+        expect(completes.length).toBe(1);
+
+        // timeout error event 부재 — opt-in default 가 enforced.
+        const timeoutErrors = events.filter(
+          (e) => e.type === 'error' && /timeout/i.test(e.error)
+        );
+        expect(timeoutErrors.length).toBe(0);
       } finally {
         if (originalEnv === undefined) delete process.env.DREAMPIA_VCR_FIXTURE;
         else process.env.DREAMPIA_VCR_FIXTURE = originalEnv;


### PR DESCRIPTION
## Summary

v1.9.0 Phase A3 deliverable per [docs/v2.x-roadmap.md](docs/v2.x-roadmap.md). CliProviderOptions에 `timeout_ms` 옵션 추가 — set 시 spawn 후 N ms 경과 시 SIGTERM kill + 명시적 `error` StreamEvent emit. default = undefined (opt-in).

## Decisions resolved (이 세션)

v2.x roadmap Open Questions 5/5 사용자 결정 (commit `9c82f19`):
- semver 분리: A→v1.9.0, B→v2.0.0
- MetadataExtra strict: v2.0.0
- F4 격리: utility_process
- VCR_MODE prod gate: startup fail
- Phase D 우선순위: Chat virtualization

## Changes

| File | Purpose |
|------|---------|
| `src/providers/cli/CliProvider.ts` | `timeout_ms` 필드 + `onTimeout` setTimeout + `timedOut` flag (aborted와 분리) + close/error/finally clearTimeout |
| `src/providers/auto.ts` | `parseTimeoutMsEnv()` + `DREAMPIA_CLI_TIMEOUT_MS` wire (cliOverride + makeCliProvider 양 경로) |
| `tests/providers/cli/fakeCliReplay.test.ts` | drive16-4 timeout + opt-in regression (vitest) |
| `e2e/_drive16.spec.ts` | drive16-3 timeout (Playwright) |
| `e2e/fixtures-vcr.ts` | `cliTimeoutMs` option + conditional env injection |
| `docs/adr/0001-cli-provider-timeout.md` | 첫 ADR (context/decision/alts/semantics/consequences) |

## Semantics — `signal` (user-cancel) vs `timeout_ms`

| | `signal.abort()` | `timeout_ms` 경과 |
|---|---|---|
| `aborted` flag | true | false |
| `timedOut` flag | false | true |
| `error` StreamEvent emit | 안 함 (silent return) | emit |
| UI 표면 | `cancelled` | `failed` (error 표시) |

## Verification

- **Vitest**: 27/27 PASS (CLI 서브셋, drive16-4 timeout 312ms / regression 1033ms)
  - 로컬 SQLite ABI mismatch로 full sweep 막힘 — CI ubuntu에서 통과 검증
- **Typecheck**: 0 errors
- **Prettier**: clean (lint 회피)
- **Architect verify**: 5/5 ship now — race-free, cleanup 3 paths, env consistent

## Follow-ups (defer-OK per architect)

- e2e drive16-3 text-level assertion (현재 cursor-disappearance만 — error testid 부재, Phase C e2e sweep 슬롯에 적합)
- `onAbort` clearTimeout (style, finally가 backstop)
- `settings.json cli_timeout_ms` UI (별도 슬롯, ADR Future Work 명시)

## Test plan

- [ ] CI: Lint, TypeScript, Test (ubuntu/windows/macos), Build, E2E 모두 그린
- [ ] vitest fakeCliReplay drive16-4 timeout PASS (CI ubuntu)
- [ ] e2e drive16-3 timeout PASS (Playwright on ubuntu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)