### PR TITLE
feat(security): A4 — VCR / fake-CLI production gate (v1.9.0 Phase A)

### DIFF
--- a/docs/v2.x-roadmap.md
+++ b/docs/v2.x-roadmap.md
@@ -28,7 +28,7 @@
 | ID | 항목 | Effort | 권고 순서 |
 |----|------|:---:|:---:|
 | A1 | **L1 respond audit log** — `permission/respond` IPC 핸들러에서 `AuditLogStore` 에 `permission.granted/denied` event emit | 0.5일 | 1 |
-| A2 | **F3/H2 PermissionRequest discriminator** — zod discriminated union + 11 파일 type narrow 통일 | 1일 | 2 |
+| A2 | **PermissionRequest hardening** — ~~discriminator union~~ deferred to v2.0.0 (2026-05-08 inventory: 모든 variants uniform shape, type narrowing 가치 minimal). zod schema는 v2.0.0 Phase B 와 함께 IPC validation 으로 통합 land. | (deferred) | — |
 | A3 | **drive16-4 timeout** — `CliProviderOptions.timeout_ms` 추가 + ADR + e2e | 1-2일 | 3 |
 | A4 | **VCR production gate** — `auto.ts` 외 production CliProvider entry 에 `shouldRequireFixture` 검증 + startup log + e2e gate | 1일 | 4 |
 | A5 | **MetadataExtra legacy optional 결정** — `plan.active`, `permission.default_level` 두 필드 strict removal vs 유지 ADR | 0.5-1일 | 5 |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -259,6 +259,27 @@ app.whenReady().then(async () => {
     console.warn(`[main] Telemetry bootstrap failed (non-fatal): ${msg}`);
   }
 
+  // v1.9.0 (A4) — VCR production gate.
+  // Spec: docs/v1.x-completion-audit.md (HIGH), 사용자 결정 2026-05-08.
+  // packaged build 에서 DREAMPIA_VCR_MODE 가 set 됐으면 test fixture 누출
+  // 가능성 — startup 즉시 차단. unpackaged (e2e/dev) 는 통과.
+  {
+    const { vcrProductionGate } = await import('../providers/cli/vcrLoader');
+    const gate = vcrProductionGate({
+      isPackaged: app.isPackaged,
+      vcrMode: process.env.DREAMPIA_VCR_MODE,
+      cliCommand: process.env.DREAMPIA_CLI_COMMAND,
+    });
+    if (!gate.ok) {
+      console.error(`[main] STARTUP FAIL (VCR gate): ${gate.message}`);
+      if (app.isPackaged) {
+        dialog.showErrorBox('Dreampia-Dev — VCR 모드 차단', gate.message);
+      }
+      app.exit(1);
+      return;
+    }
+  }
+
   // Open session DB at OS-specific user data dir.
   //   Windows: %APPDATA%/Dreampia-Dev/sessions.sqlite
   //   macOS:   ~/Library/Application Support/Dreampia-Dev/sessions.sqlite

--- a/src/providers/cli/vcrLoader.ts
+++ b/src/providers/cli/vcrLoader.ts
@@ -220,3 +220,53 @@ export function updateFixtureHash(fixturePath: string, capturedEvents: StreamEve
 export function shouldRequireFixture(mode: VcrMode = getVcrMode()): boolean {
   return mode === 'replay';
 }
+
+/**
+ * v1.9.0 (A4) — VCR / fake-CLI production gate.
+ *
+ * Spec: docs/v1.x-completion-audit.md (HIGH severity), 사용자 결정 2026-05-08:
+ *   "DREAMPIA_VCR_MODE production: startup fail (test fixture prod 누출 차단)".
+ *
+ * 차단 대상 env (architect verify 2026-05-09: 같은 보안 경계 — fake-CLI 우회):
+ *   - `DREAMPIA_VCR_MODE`     — VCR replay/record/live 모드
+ *   - `DREAMPIA_CLI_COMMAND`  — CliProvider binary override (test fake CLI)
+ *
+ * Returns `{ ok: false, message }` 면 호출자 (main/index.ts) 가 dialog 표시
+ * 후 `app.exit(1)` 로 즉시 종료해야 한다.
+ *
+ * 통과 조건 (모두 ok):
+ *  - unpackaged build (app.isPackaged === false): VCR env set 여부 무관
+ *  - packaged build + 두 env 모두 undefined
+ *
+ * 차단 조건 (fail):
+ *  - packaged build + 두 env 중 하나라도 string (값 무관 — typo / silent
+ *    coercion 차단; getVcrMode 가 unknown → replay 로 강제하는 거동 보호)
+ *
+ * Pure function — `app` 모듈 의존성 없이 호출자가 isPackaged 를 주입한다.
+ * 단위 테스트가 쉽고 main/index.ts 내 wiring 이 최소화된다.
+ */
+export function vcrProductionGate(args: {
+  isPackaged: boolean;
+  vcrMode: string | undefined;
+  cliCommand?: string | undefined;
+}): { ok: true } | { ok: false; message: string } {
+  if (!args.isPackaged) return { ok: true };
+  if (args.vcrMode !== undefined) {
+    return {
+      ok: false,
+      message:
+        `VCR mode detected in production build (DREAMPIA_VCR_MODE=${args.vcrMode}). ` +
+        `Test fixtures must not leak into production. Application will exit.`,
+    };
+  }
+  if (args.cliCommand !== undefined) {
+    return {
+      ok: false,
+      message:
+        `Fake CLI override detected in production build ` +
+        `(DREAMPIA_CLI_COMMAND=${args.cliCommand}). ` +
+        `Test harness must not leak into production. Application will exit.`,
+    };
+  }
+  return { ok: true };
+}

--- a/tests/providers/cli/vcrLoader.test.ts
+++ b/tests/providers/cli/vcrLoader.test.ts
@@ -21,6 +21,7 @@ import {
   detectDrift,
   updateFixtureHash,
   shouldRequireFixture,
+  vcrProductionGate,
   VcrFixtureMissingError,
   VcrFixtureInvalidError,
 } from '../../../src/providers/cli/vcrLoader';
@@ -194,5 +195,79 @@ describe('v1.1.10 — VcrLoader.shouldRequireFixture', () => {
   });
   it("'live' → false", () => {
     expect(shouldRequireFixture('live')).toBe(false);
+  });
+});
+
+// v1.9.0 (A4) — VCR production gate. spec: docs/v1.x-completion-audit.md (HIGH).
+// 사용자 결정 2026-05-08: "DREAMPIA_VCR_MODE production: startup fail".
+describe('v1.9.0 — VcrLoader.vcrProductionGate', () => {
+  it('unpackaged + vcrMode unset → ok', () => {
+    const r = vcrProductionGate({ isPackaged: false, vcrMode: undefined });
+    expect(r.ok).toBe(true);
+  });
+  it('unpackaged + vcrMode replay (e2e/dev) → ok', () => {
+    const r = vcrProductionGate({ isPackaged: false, vcrMode: 'replay' });
+    expect(r.ok).toBe(true);
+  });
+  it('packaged + vcrMode unset (production normal) → ok', () => {
+    const r = vcrProductionGate({ isPackaged: true, vcrMode: undefined });
+    expect(r.ok).toBe(true);
+  });
+  it('packaged + vcrMode replay → fail with message', () => {
+    const r = vcrProductionGate({ isPackaged: true, vcrMode: 'replay' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toMatch(/VCR mode detected in production build/);
+      expect(r.message).toMatch(/DREAMPIA_VCR_MODE=replay/);
+      expect(r.message).toMatch(/Test fixtures must not leak into production/);
+    }
+  });
+  it('packaged + vcrMode record → fail (test fixture write 가능성도 차단)', () => {
+    const r = vcrProductionGate({ isPackaged: true, vcrMode: 'record' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toMatch(/DREAMPIA_VCR_MODE=record/);
+  });
+  it('packaged + vcrMode live → fail (any value blocked)', () => {
+    const r = vcrProductionGate({ isPackaged: true, vcrMode: 'live' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toMatch(/DREAMPIA_VCR_MODE=live/);
+  });
+  it('packaged + vcrMode 빈 문자열 → fail (any non-undefined string blocked)', () => {
+    const r = vcrProductionGate({ isPackaged: true, vcrMode: '' });
+    expect(r.ok).toBe(false);
+  });
+
+  // architect verify 2026-05-09 추가: DREAMPIA_CLI_COMMAND 도 같은 보안 경계.
+  it('packaged + cliCommand set → fail (fake-CLI override 차단)', () => {
+    const r = vcrProductionGate({
+      isPackaged: true,
+      vcrMode: undefined,
+      cliCommand: '/path/to/fake-cli',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toMatch(/Fake CLI override detected/);
+      expect(r.message).toMatch(/DREAMPIA_CLI_COMMAND=/);
+    }
+  });
+  it('packaged + 두 env 모두 set → vcrMode 우선 메시지', () => {
+    const r = vcrProductionGate({
+      isPackaged: true,
+      vcrMode: 'replay',
+      cliCommand: '/path/to/fake-cli',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toMatch(/VCR mode detected/);
+      expect(r.message).not.toMatch(/Fake CLI override/);
+    }
+  });
+  it('unpackaged + cliCommand set (e2e fixture-vcr) → ok', () => {
+    const r = vcrProductionGate({
+      isPackaged: false,
+      vcrMode: undefined,
+      cliCommand: '/path/to/fake-cli',
+    });
+    expect(r.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

v1.9.0 Phase A4 deliverable per [docs/v2.x-roadmap.md](docs/v2.x-roadmap.md). HIGH severity finding from [v1.x-completion-audit.md:45](docs/v1.x-completion-audit.md). 사용자 결정 2026-05-08: **startup fail** (test fixture prod 누출 차단 — 가장 안전).

## Score-driven 우회

원래 점수표 #4 = A2 (PermissionRequest discriminator, 32점) 였으나 inventory 결과 PermissionRequest variants가 모두 uniform shape → type narrowing 가치 minimal로 판명. v2.0.0 Phase B로 defer. **A4 (38점, HIGH severity)** 가 점수상 우선이라 swap.

## Changes

| File | Purpose |
|------|---------|
| `src/providers/cli/vcrLoader.ts` | `vcrProductionGate({ isPackaged, vcrMode, cliCommand })` pure function |
| `src/main/index.ts` | Boot sequence wire — `app.whenReady()` 시작 직후, `SessionStore` init 전 |
| `tests/providers/cli/vcrLoader.test.ts` | 10 gate 케이스 (truth table 전체) |
| `docs/v2.x-roadmap.md` | A2 v2.0.0 defer 명시 |

## Architect verify 4.5/5 + sister vulnerability included

처음 설계는 `DREAMPIA_VCR_MODE` 만 차단했으나 architect verify 에서 **`DREAMPIA_CLI_COMMAND` 도 같은 보안 경계** (fake-CLI inject 단독 vector) 라고 지적. 본 PR에 포함:

| Env | 차단? | 이유 |
|---|---|---|
| `DREAMPIA_VCR_MODE` | ✅ | replay/record/live 모든 값 (typo + getVcrMode silent coercion 차단) |
| `DREAMPIA_CLI_COMMAND` | ✅ | fake CLI binary override 단독으로도 inject 가능 |
| `DREAMPIA_TEST` | — | 이미 `auto.ts:115-121` 에서 mock provider 강제 (별 메커니즘) |

## Boot flow

```
app.whenReady()
  → telemetry bootstrap (non-fatal)
  → ★ vcrProductionGate (NEW) ─── packaged + VCR/fake-CLI env → app.exit(1)
  → SessionStore init
  → integrity check
  → window create
```

`app.isPackaged === false` (e2e, dev) 는 항상 통과 — 기존 drive14-17 e2e 가 implicitly cover.

## Verification

- **vitest**: 28/28 PASS (truth table: unpackaged×{unset,replay,cliCommand}, packaged×{unset,replay,record,live,empty,cliCommand,both}, 메시지 우선순위)
- **typecheck**: 0 errors
- **prettier**: clean (lint 회피)
- **architect**: 4.5/5 ship now, must-fix 0건

## Suggested follow-up (defer-OK per architect)

- Release-checklist에 manual smoke step 추가: "packaged build + DREAMPIA_VCR_MODE=replay 실행 시 dialog + exit 1 확인" → Phase C `release-checklist.md` 정식화 슬롯에 적합

## Test plan

- [ ] CI: Lint, TypeScript, Test (ubuntu/windows/macos), Build, E2E 모두 그린
- [ ] vitest vcrLoader 28/28 PASS (CI ubuntu)
- [ ] e2e drive14-17 회귀 없음 (gate가 unpackaged path를 차단하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)