### PR TITLE
feat(tools): A2 — PermissionRequestSchema (zod) for IPC validation (v2.0.0 Phase B)

### DIFF
--- a/src/tools/permissionRequestSchema.ts
+++ b/src/tools/permissionRequestSchema.ts
@@ -1,0 +1,66 @@
+/**
+ * v2.0.0 (A2) — `PermissionRequest` 의 zod schema.
+ *
+ * 책임:
+ *  - IPC boundary 에서 main → renderer 로 전송되는 `PermissionRequest` 의
+ *    runtime validation. 잘못된 shape 가 renderer 로 새는 것 차단.
+ *  - 향후 strict union (kind discriminator) 으로 확장 가능한 토대.
+ *
+ * Spec: docs/v2.x-roadmap.md (A2 Phase B 통합 land)
+ *
+ * 본 schema 는 현재 모든 PermissionRequest variants (Tool / Plugin /
+ * High-risk) 가 동일 shape 라는 ralph 세션 inventory 결과를 반영한다 —
+ * 단일 schema + `kind` literal marker 로 충분. 향후 variant 별 다른 shape 가
+ * 필요해지면 `z.discriminatedUnion('kind', [...])` 로 확장.
+ */
+
+import { z } from 'zod';
+import { SessionIdSchema, TurnIdSchema, ToolCallIdSchema, ISO8601Schema } from '../types/common';
+
+// ────────────────────────────────────────────────────────────
+// PermissionTargetKind — types.ts 의 string union 과 동기.
+// ────────────────────────────────────────────────────────────
+
+export const PermissionTargetKindSchema = z.enum(['path', 'url', 'domain', 'global']);
+
+// ────────────────────────────────────────────────────────────
+// PermissionRequestSchema
+// ────────────────────────────────────────────────────────────
+
+export const PermissionRequestSchema = z.object({
+  /**
+   * v2.0.0 (A2) — discriminator marker. 현재 단일 variant 'permission_confirmation'.
+   * 향후 plugin / tool 분리 시 z.literal 추가 예정. 미지정 (legacy) 호환을 위해
+   * `.default()` 로 자동 채움.
+   */
+  kind: z.literal('permission_confirmation').default('permission_confirmation'),
+  request_id: z.string().min(1),
+  session_id: SessionIdSchema,
+  turn_id: TurnIdSchema,
+  call_id: ToolCallIdSchema,
+  tool_id: z.string().min(1),
+  capability: z.string().min(1),
+  target: z.object({
+    kind: PermissionTargetKindSchema,
+    value: z.string(),
+  }),
+  hint: z.string().optional(),
+  is_dangerous: z.boolean(),
+  tool_display_name: z.string(),
+  requested_at: ISO8601Schema,
+});
+
+/**
+ * Zod 가 추론한 type. legacy `PermissionRequest` interface 와 호환되어야
+ * 한다 — `kind` 필드만 추가됐고 default 가 있어 caller 가 set 안 해도 OK.
+ */
+export type PermissionRequestZod = z.infer<typeof PermissionRequestSchema>;
+
+/**
+ * IPC boundary 의 safeParse helper. 잘못된 shape 면 `null` 반환 + 호출자가
+ * audit / drop 결정. throw X — fail-closed pattern.
+ */
+export function parsePermissionRequest(raw: unknown): PermissionRequestZod | null {
+  const result = PermissionRequestSchema.safeParse(raw);
+  return result.success ? result.data : null;
+}

--- a/tests/tools/permissionRequestSchema.test.ts
+++ b/tests/tools/permissionRequestSchema.test.ts
@@ -1,0 +1,129 @@
+/**
+ * v2.0.0 (A2) — PermissionRequestSchema unit tests.
+ *
+ * 검증:
+ *  - valid shape → safeParse success + kind default 적용
+ *  - kind 명시 시 그 값 유지
+ *  - 필수 필드 누락 → fail
+ *  - target 의 kind 가 잘못된 enum → fail
+ *  - 빈 문자열 / 잘못된 ISO8601 → fail
+ *  - parsePermissionRequest helper 가 null 반환 (throw X)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PermissionRequestSchema,
+  parsePermissionRequest,
+} from '../../src/tools/permissionRequestSchema';
+
+// SessionIdSchema 가 UUIDv7 강제 — 7번째 nibble='7', 17번째 nibble∈[8-b].
+const validRequest = {
+  request_id: 'req-1',
+  session_id: '01890c1c-9c47-7a3f-bf24-aabbccddeeff',
+  turn_id: 'turn-xyz-456',
+  call_id: 'call-uvw-789',
+  tool_id: 'shell.run',
+  capability: 'LOCAL_EXECUTE',
+  target: { kind: 'global', value: '' },
+  is_dangerous: false,
+  tool_display_name: 'Shell Run',
+  requested_at: '2026-05-09T00:00:00.000Z',
+};
+
+describe('v2.0.0 (A2) — PermissionRequestSchema', () => {
+  it('valid shape → safeParse success + kind default = permission_confirmation', () => {
+    const result = PermissionRequestSchema.safeParse(validRequest);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.kind).toBe('permission_confirmation');
+      expect(result.data.request_id).toBe('req-1');
+      expect(result.data.target.kind).toBe('global');
+    }
+  });
+
+  it('kind 명시 = permission_confirmation 도 통과', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      kind: 'permission_confirmation',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('kind 다른 값 → fail (literal mismatch)', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      kind: 'something-else',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('request_id 빈 문자열 → fail', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      request_id: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('target.kind 가 enum 외 값 → fail', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      target: { kind: 'badkind', value: '' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('target 누락 → fail', () => {
+    const { target: _t, ...withoutTarget } = validRequest;
+    void _t;
+    const result = PermissionRequestSchema.safeParse(withoutTarget);
+    expect(result.success).toBe(false);
+  });
+
+  it('is_dangerous 가 boolean 아님 → fail', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      is_dangerous: 'no',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requested_at 가 ISO8601 아님 → fail', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      requested_at: 'not-a-date',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('hint optional — 누락 OK', () => {
+    const result = PermissionRequestSchema.safeParse(validRequest);
+    expect(result.success).toBe(true);
+  });
+
+  it('hint 지정 시 그 값 유지', () => {
+    const result = PermissionRequestSchema.safeParse({
+      ...validRequest,
+      hint: 'Tool 이 X 폴더에 쓰기를 요청합니다',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hint).toMatch(/X 폴더/);
+    }
+  });
+});
+
+describe('v2.0.0 (A2) — parsePermissionRequest helper', () => {
+  it('valid → 데이터 반환', () => {
+    const data = parsePermissionRequest(validRequest);
+    expect(data).not.toBeNull();
+    expect(data?.kind).toBe('permission_confirmation');
+  });
+
+  it('invalid → null (throw X — fail-closed)', () => {
+    expect(parsePermissionRequest({ broken: true })).toBeNull();
+    expect(parsePermissionRequest(null)).toBeNull();
+    expect(parsePermissionRequest(undefined)).toBeNull();
+    expect(parsePermissionRequest('string')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

v2.0.0 — A2 deliverable (deferred from Phase A per Open Questions Q1). 사용자 결정: A2 zod schema 는 v2.0.0 Phase B 에 통합. 본 PR 은 schema + safeParse helper + 12 test cases.

## Changes

| File | LOC | Purpose |
|---|---|---|
| `src/tools/permissionRequestSchema.ts` | +60 | `PermissionRequestSchema` + `parsePermissionRequest` helper |
| `tests/tools/permissionRequestSchema.test.ts` | +130 | 12 cases (valid/invalid shapes + helper fail-closed) |

## Schema design

```ts
PermissionRequestSchema = z.object({
  kind: z.literal('permission_confirmation').default(...),  // discriminator marker
  request_id: z.string().min(1),
  session_id: SessionIdSchema,           // UUIDv7 강제
  turn_id: TurnIdSchema,
  call_id: ToolCallIdSchema,
  tool_id: z.string().min(1),
  capability: z.string().min(1),
  target: z.object({ kind: PermissionTargetKindSchema, value: z.string() }),
  hint: z.string().optional(),
  is_dangerous: z.boolean(),
  tool_display_name: z.string(),
  requested_at: ISO8601Schema,
});
```

- ralph 세션 inventory 발견: 모든 variants (Tool / Plugin / High-risk) uniform shape — discriminated union 불필요. 단일 schema + `kind` literal marker 로 충분.
- 향후 variant 분리 시 `z.discriminatedUnion('kind', [...])` 로 확장.

## Helper

`parsePermissionRequest(raw): PermissionRequestZod | null` — IPC boundary 의 fail-closed safeParse. throw X — caller 가 audit / drop 결정.

## Test plan

- [ ] CI: Lint, TypeScript, Test ×3, Build ×3, E2E green
- [ ] 12 cases PASS

## Follow-ups (defer to dedicated slot)

- IPC boundary wiring — `permission/respond` 등 handler 에서 `parsePermissionRequest()` 호출 + 실패 시 audit + drop
- 11 consumer files type narrow 정리 (현재 uniform shape 라 priority 낮음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)