### PR TITLE
feat(storage): MetadataExtra strict — migration 016 + schema removal (v2.0.0)

### DIFF
--- a/src/storage/metadataExtraSchema.ts
+++ b/src/storage/metadataExtraSchema.ts
@@ -68,11 +68,8 @@ const BrowserExtraSchema = z
 
 const PlanExtraSchema = z
   .object({
-    /**
-     * v1.8.4 legacy optional. column `sessions.plan_active` 가 단일 source.
-     * 신규 row 는 본 필드 직렬화 X — 기존 row 만 read 호환용.
-     */
-    active: z.boolean().optional(),
+    // v2.0.0 (ADR-0002): plan.active 제거. column `sessions.plan_active` 가
+    // 단일 source. migration 016 이 모든 row 의 _extra 에서 strip.
     browser_tool_enabled: z.boolean(),
     current_item_index: z.number().optional(),
   })
@@ -80,11 +77,9 @@ const PlanExtraSchema = z
 
 const PermissionExtraSchema = z
   .object({
-    /**
-     * v1.8.4 legacy optional. column `sessions.permission_default_level`
-     * 가 단일 source. 신규 row 는 본 필드 직렬화 X.
-     */
-    default_level: z.enum(['read_only', 'workspace_write', 'full_access', 'custom']).optional(),
+    // v2.0.0 (ADR-0002): permission.default_level 제거. column
+    // `sessions.permission_default_level` 가 단일 source. migration 016 이
+    // 모든 row 의 _extra 에서 strip.
     last_denied: z.object({ capability: z.string(), ts: z.string() }).optional(),
     temporarily_blocked_capabilities: z.array(z.string()),
   })

--- a/src/storage/migrate.ts
+++ b/src/storage/migrate.ts
@@ -29,6 +29,7 @@ import sql012 from './migrations/012_workspace_id_sha256_marker.sql?raw';
 import sql013 from './migrations/013_permission_grants_id_text.sql?raw';
 import sql014 from './migrations/014_conversation_columns_promote.sql?raw';
 import sql015 from './migrations/015_extra_promote_v1.sql?raw';
+import sql016 from './migrations/016_metadata_extra_strict_strip.sql?raw';
 
 // v1.4.3 — down migrations. 일부 (markers 8-12) 만 backfill, 1-7 은 후속.
 import down008 from './migrations/down_008_workspace_id_deterministic.sql?raw';
@@ -39,6 +40,7 @@ import down012 from './migrations/down_012_workspace_id_sha256_marker.sql?raw';
 import down013 from './migrations/down_013_permission_grants_id_text.sql?raw';
 import down014 from './migrations/down_014_conversation_columns_promote.sql?raw';
 import down015 from './migrations/down_015_extra_promote_v1.sql?raw';
+import down016 from './migrations/down_016_metadata_extra_strict_strip.sql?raw';
 
 // ────────────────────────────────────────────────────────────
 // Migration registry
@@ -120,6 +122,13 @@ const MIGRATIONS: readonly Migration[] = [
     description: 'v1.8.1 — sessions.permission_default_level + plan_active promote (B-3 2단계)',
     up: sql015,
     down: down015,
+  },
+  {
+    version: 16,
+    description:
+      'v2.0.0 — metadata_json._extra strict strip (plan.active + permission.default_level) — ADR-0002',
+    up: sql016,
+    down: down016,
   },
 ] as const;
 

--- a/src/storage/migrations/016_metadata_extra_strict_strip.sql
+++ b/src/storage/migrations/016_metadata_extra_strict_strip.sql
@@ -1,0 +1,29 @@
+-- 016_metadata_extra_strict_strip.sql — v2.0.0 (ADR-0002 implementation).
+-- Spec: docs/adr/0002-metadata-extra-legacy-optional.md
+--
+-- 개요
+-- ────────────
+--   v1.8.4 부터 buildStoredMetadata 는 plan.active / permission.default_level
+--   을 _extra 에 직렬화하지 않음 (column 만 source). 그러나 schema 의
+--   `.optional()` 가 pre-v1.8.4 row 호환을 위해 유지됨.
+--
+--   v2.0.0 의 strict removal 흐름:
+--     1. 모든 row 의 metadata_json._extra 에서 두 필드 제거 (본 migration).
+--     2. metadataExtraSchema.ts 에서 두 필드 삭제 (Phase B 코드 변경).
+--     3. extraSchemaContract.test.ts 가 두 필드 strict reject 검증.
+--
+-- INV: row 수 보존. 컬럼 (permission_default_level / plan_active) 변경 X.
+--      migration 015 이후 모든 row 는 이미 두 컬럼에 정확한 값 보유.
+
+-- 두 필드 동시 strip — json_remove 가 path 부재 시 no-op (idempotent).
+-- WHERE 로 변경이 필요한 row 만 좁힘 (write 비용 절감).
+UPDATE sessions
+SET metadata_json = json_remove(
+    json_remove(metadata_json, '$._extra.plan.active'),
+    '$._extra.permission.default_level'
+)
+WHERE metadata_json IS NOT NULL
+  AND (
+      json_extract(metadata_json, '$._extra.plan.active') IS NOT NULL
+      OR json_extract(metadata_json, '$._extra.permission.default_level') IS NOT NULL
+  );

--- a/src/storage/migrations/down_016_metadata_extra_strict_strip.sql
+++ b/src/storage/migrations/down_016_metadata_extra_strict_strip.sql
@@ -1,0 +1,25 @@
+-- down_016_metadata_extra_strict_strip.sql — v2.0.0 down.
+-- Spec: docs/adr/0002-metadata-extra-legacy-optional.md
+--
+-- 016 은 metadata_json._extra 에서 legacy 두 필드 제거. down 은 promoted
+-- column 에서 다시 _extra 에 set — pre-v1.8.4 호환 형태로 복원. column
+-- 자체는 015 부터 유지되므로 동일 데이터.
+
+-- permission.default_level 복원 (column 이 NULL 아닌 row 만).
+UPDATE sessions
+SET metadata_json = json_set(
+    metadata_json,
+    '$._extra.permission.default_level',
+    permission_default_level
+)
+WHERE metadata_json IS NOT NULL
+  AND permission_default_level IS NOT NULL;
+
+-- plan.active 복원 — boolean 으로 set (json() wrap 으로 SQLite 가 JSON true/false 처리).
+UPDATE sessions
+SET metadata_json = json_set(
+    metadata_json,
+    '$._extra.plan.active',
+    json(CASE plan_active WHEN 1 THEN 'true' ELSE 'false' END)
+)
+WHERE metadata_json IS NOT NULL;

--- a/tests/storage/extraColumnPromote.test.ts
+++ b/tests/storage/extraColumnPromote.test.ts
@@ -64,9 +64,9 @@ describe('v1.8.1 — _extra column promote', () => {
     store.close();
   });
 
-  it('migration registry — LATEST_SCHEMA_VERSION === 15', () => {
-    expect(LATEST_SCHEMA_VERSION).toBe(15);
-    expect(store.getSchemaVersion()).toBe(15);
+  it('migration registry — LATEST_SCHEMA_VERSION === 16 (v2.0.0 ADR-0002 strict strip)', () => {
+    expect(LATEST_SCHEMA_VERSION).toBe(16);
+    expect(store.getSchemaVersion()).toBe(16);
   });
 
   it('v1.8.4 — INSERT 시 column 만 채워지고 _extra 측 두 필드 부재', () => {

--- a/tests/storage/extraSchemaContract.test.ts
+++ b/tests/storage/extraSchemaContract.test.ts
@@ -85,9 +85,8 @@ describe('v1.8.2 — _extra MetadataExtraSchema contract', () => {
         layout: 'hidden',
         partition_id: 'p',
       },
-      plan: { active: false, browser_tool_enabled: false },
+      plan: { browser_tool_enabled: false },
       permission: {
-        default_level: 'workspace_write',
         temporarily_blocked_capabilities: [],
       },
       // 미등록 namespace.
@@ -117,9 +116,8 @@ describe('v1.8.2 — _extra MetadataExtraSchema contract', () => {
         layout: 'hidden',
         partition_id: 'p',
       },
-      plan: { active: false, browser_tool_enabled: false },
+      plan: { browser_tool_enabled: false },
       permission: {
-        default_level: 'workspace_write',
         temporarily_blocked_capabilities: [],
       },
     };
@@ -141,9 +139,8 @@ describe('v1.8.2 — _extra MetadataExtraSchema contract', () => {
         layout: 'hidden',
         partition_id: 'p',
       },
-      plan: { active: false, browser_tool_enabled: false },
+      plan: { browser_tool_enabled: false },
       permission: {
-        default_level: 'workspace_write',
         temporarily_blocked_capabilities: [],
       },
     };
@@ -260,7 +257,7 @@ describe('v1.8.2 — _extra MetadataExtraSchema contract', () => {
     expect(r.success).toBe(false);
   });
 
-  it('permission.default_level enum 강제 (잘못된 값 거부)', () => {
+  it('v2.0.0 (ADR-0002) — permission.default_level 가 들어오면 거부 (legacy strict removal)', () => {
     const sample = {
       conversation: {
         current_model: 'sonnet',
@@ -274,9 +271,39 @@ describe('v1.8.2 — _extra MetadataExtraSchema contract', () => {
         layout: 'hidden',
         partition_id: 'p',
       },
-      plan: { active: false, browser_tool_enabled: false },
+      plan: { browser_tool_enabled: false },
       permission: {
-        default_level: 'totally_made_up',
+        // legacy field — column `sessions.permission_default_level` 단일 source.
+        // strict schema 가 reject 해야 함.
+        default_level: 'workspace_write',
+        temporarily_blocked_capabilities: [],
+      },
+    };
+    const r = MetadataExtraSchema.safeParse(sample);
+    expect(r.success).toBe(false);
+  });
+
+  it('v2.0.0 (ADR-0002) — plan.active 가 들어오면 거부 (legacy strict removal)', () => {
+    const sample = {
+      conversation: {
+        current_model: 'sonnet',
+        current_effort: 'medium',
+        current_mode: 'chat',
+      },
+      workspace: { recent_files: [], open_files: [], ignore_patterns: [] },
+      terminal: { panel_open: false, height_px: 200 },
+      browser: {
+        panel_visible: false,
+        layout: 'hidden',
+        partition_id: 'p',
+      },
+      plan: {
+        // legacy field — column `sessions.plan_active` 단일 source.
+        // strict schema 가 reject 해야 함.
+        active: true,
+        browser_tool_enabled: false,
+      },
+      permission: {
         temporarily_blocked_capabilities: [],
       },
     };


### PR DESCRIPTION
## Summary

ADR-0002 implementation. v2.0.0 의 strict removal — `_extra.plan.active` / `_extra.permission.default_level` 두 legacy 필드를 schema + DB 양쪽에서 제거.

## Changes

| File | Purpose |
|---|---|
| `src/storage/migrations/016_metadata_extra_strict_strip.sql` | 모든 row 의 `_extra` 에서 두 필드 strip |
| `src/storage/migrations/down_016_*.sql` | promoted column 에서 두 필드 복원 (down) |
| `src/storage/migrate.ts` | MIGRATIONS v=16 추가, LATEST_SCHEMA_VERSION 15→16 |
| `src/storage/metadataExtraSchema.ts` | `PlanExtraSchema.active` + `PermissionExtraSchema.default_level` 삭제 |
| `tests/storage/extraSchemaContract.test.ts` | 기존 fixture 정리 + 2 strict-reject 케이스 추가 |

## Why now (ADR-0002 timeline)

| 시점 | 상태 |
|---|---|
| v1.8.4 | `buildStoredMetadata` 직렬화 중단 (column-only write). schema legacy `.optional()` 유지 |
| **v2.0.0 (이 PR)** | schema 두 필드 삭제 + migration 016 strip |
| v2.1.0+ | strict 가 production 에서 누적 회귀 lock |

## Backward / Forward compat

- **Up**: 기존 row 의 _extra 에 legacy 필드 있으면 migration 016 이 strip → schema parse 통과
- **Down (down_016)**: `permission_default_level` / `plan_active` column 에서 _extra 로 재조립 → pre-v1.8.4 형태 복원
- **신규 row**: write 경로가 이미 column-only 이므로 schema 변경 영향 0

## Test additions

| 케이스 | 검증 |
|---|---|
| `permission.default_level` 들어오면 거부 | strict schema reject |
| `plan.active` 들어오면 거부 | strict schema reject |

기존 fixture 들 (`workspace_write` / `active: false`) 모두 정리 — 신규 schema 와 일치.

## Verification

- **typecheck**: 0 errors
- **vitest** (schema-only): 8/8 PASS — strict-reject 케이스 포함
- **prettier**: clean
- 3 SessionStore round-trip 테스트는 local SQLite ABI mismatch 로 skip — CI ubuntu 가 검증

## Test plan

- [ ] CI: Lint, TS, Test ×3, Build ×3, E2E green (CI ubuntu 가 SQLite round-trip 회귀 lock)
- [ ] migration 016 up 적용 시 모든 row metadata 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)