### PR TITLE
test(a11y): C4 — drive18 axe light theme variant (Phase C — v2.1.0)

### DIFF
--- a/e2e/_drive18_axe.spec.ts
+++ b/e2e/_drive18_axe.spec.ts
@@ -161,3 +161,105 @@ test.describe('drive18 — axe-core a11y baseline (v1.7.7)', () => {
     expect.soft(summary.serious).toBe(0);
   });
 });
+
+// ────────────────────────────────────────────────────────────
+// v2.1.0 (Phase C C4) — light theme axe variant.
+//
+// Default theme = dark (index.html). 18-1~3 이 이미 dark mode cover. 본 그룹
+// 18-4~6 은 data-theme='light' 로 강제 전환 후 같은 시나리오 재실행 — light
+// theme color-contrast / focus-indicator / link-color 등이 별도 검증.
+//
+// disableRules 는 light 와 dark 가 다를 수 있어 별도 변수.
+// 현재 비어있음 — strict baseline 시작 시점.
+// ────────────────────────────────────────────────────────────
+
+const DISABLE_RULES_LIGHT: ReadonlyArray<string> = [];
+
+async function setLightTheme(window: import('@playwright/test').Page): Promise<void> {
+  await window.evaluate(() => {
+    document.documentElement.setAttribute('data-theme', 'light');
+  });
+  // 짧은 paint 대기 — theme 변경 후 CSS 변수가 반영될 시간.
+  await window.waitForTimeout(150);
+}
+
+test.describe('drive18 — axe-core a11y baseline (v2.1.0 C4 — light theme)', () => {
+  test('18-4 — 메인 채팅 (light): critical/serious 0', async ({ window }) => {
+    await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
+      timeout: 10_000,
+    });
+    await setLightTheme(window);
+
+    const results = await runAxe(window, {
+      tags: WCAG_TAGS,
+      disableRules: DISABLE_RULES_LIGHT,
+    });
+    const summary = summarize(results.violations);
+    writeFileSync(
+      resolve(SHOT_DIR, 'r18-4-main-light.json'),
+      JSON.stringify({ summary, violations: results.violations }, null, 2),
+      'utf-8'
+    );
+    expect.soft(summary.critical).toBe(0);
+    expect.soft(summary.serious).toBe(0);
+    expect(true).toBe(true);
+  });
+
+  test('18-5 — settings 모달 mcp 탭 (light): critical/serious 0', async ({
+    window,
+  }) => {
+    await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
+      timeout: 10_000,
+    });
+    await setLightTheme(window);
+    await window.evaluate(() => document.body.focus());
+    await window.keyboard.press('ControlOrMeta+,');
+    await expect(window.getByTestId('settings-modal')).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const results = await runAxe(window, {
+      tags: WCAG_TAGS,
+      disableRules: DISABLE_RULES_LIGHT,
+    });
+    const summary = summarize(results.violations);
+    writeFileSync(
+      resolve(SHOT_DIR, 'r18-5-settings-mcp-light.json'),
+      JSON.stringify({ summary, violations: results.violations }, null, 2),
+      'utf-8'
+    );
+    expect.soft(summary.critical).toBe(0);
+    expect.soft(summary.serious).toBe(0);
+  });
+
+  test('18-6 — settings [Direct API] (light): critical/serious 0', async ({
+    window,
+  }) => {
+    await expect(window.getByTestId('sidebar-search-input')).toBeVisible({
+      timeout: 10_000,
+    });
+    await setLightTheme(window);
+    await window.evaluate(() => document.body.focus());
+    await window.keyboard.press('ControlOrMeta+,');
+    await expect(window.getByTestId('settings-modal')).toBeVisible({
+      timeout: 5_000,
+    });
+    await window.getByTestId('settings-tab-direct_api').click();
+    await expect(window.getByTestId('settings-direct-api-panel')).toBeVisible({
+      timeout: 3_000,
+    });
+
+    const results = await runAxe(window, {
+      tags: WCAG_TAGS,
+      disableRules: DISABLE_RULES_LIGHT,
+    });
+    const summary = summarize(results.violations);
+    writeFileSync(
+      resolve(SHOT_DIR, 'r18-6-settings-direct-api-light.json'),
+      JSON.stringify({ summary, violations: results.violations }, null, 2),
+      'utf-8'
+    );
+    expect.soft(summary.critical).toBe(0);
+    expect.soft(summary.serious).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

v2.1.0 Phase C C4. drive18 axe-core baseline 이 dark theme (default) 만 cover 하던 gap 회수. 18-4/5/6 light theme 변형 추가.

## Changes

| File | LOC | Purpose |
|---|---|---|
| `e2e/_drive18_axe.spec.ts` | +102 | 3 light theme variants |

## Approach

- `setLightTheme(window)` helper — `data-theme='light'` 설정 + paint 150ms
- 기존 18-1/2/3 시나리오를 light 로 재실행 (메인 채팅 + settings mcp + Direct API)
- 결과는 별도 JSON dump 파일 (r18-4/5/6-*-light.json)
- DISABLE_RULES_LIGHT 변수로 dark/light 분리 가능 (현재 0)

## Why

light theme 색 토큰이 dark 와 contrast ratio 가 다를 수 있음. 본 PR 이 baseline 을 lock 하면 향후 token 변경 시 light/dark 양쪽 회귀 자동 감지.

## Test plan

- [ ] CI: Lint, TS, Test ×3, Build ×3, E2E green
- [ ] 18-4/5/6 PASS — 만약 light theme 의 critical/serious > 0 이면 token 조정 후속 PR (v1.1.7 strict baseline 회복 패턴 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)