### PR TITLE
test(e2e): C5 — regression sweep stubs (Phase C — v2.1.0)

### DIFF
--- a/e2e/_drive_automation_cron_tz.spec.ts
+++ b/e2e/_drive_automation_cron_tz.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * drive_automation_cron_tz — Automation cron timezone 정합 (v2.1.0 C5 stub).
+ *
+ * Spec: docs/v2.x-roadmap.md (Phase C C5 — e2e regression sweep).
+ * Status: STUB — 시나리오 정의 + skip annotation. 실제 implementation 은
+ * v2.1.x 후속 슬롯.
+ *
+ * 목적
+ * ────────────
+ * AutomationManager 의 cron schedule 이 사용자 시스템 timezone 을 정확히
+ * 따르는지 회귀 lock. UTC drift / DST transition / 사용자 manual TZ 변경
+ * 모두 cover.
+ *
+ * 시나리오 (구현 시 활성):
+ *   - DACT-1: cron '0 9 * * *' 등록 시 사용자 local 9AM 에 fire (시스템 TZ)
+ *   - DACT-2: settings 의 timezone override (있으면) 가 cron 평가에 반영
+ *   - DACT-3: DST spring-forward (US: 2026-03-08) 시 02:30 cron 이 03:30
+ *            으로 이동 (croner 의 default 동작 lock)
+ *   - DACT-4: DST fall-back (US: 2026-11-01) 시 01:30 cron 이 한 번만 fire
+ *            (중복 방지)
+ *   - DACT-5: 사용자가 노트북을 다른 TZ 로 들고 가서 system TZ 변경 시
+ *            기존 ruleset 의 next-fire 가 자동 재평가
+ *
+ * 인프라 요구사항:
+ *   - vitest fake timers (croner 와 호환 시)
+ *   - 또는 Playwright 가 process.env.TZ override 해서 Electron 띄우기
+ *   - AutomationManager 의 fire history (rule_name + fired_at) 조회 IPC
+ */
+
+import { test } from './fixtures';
+
+test.describe.skip('drive_automation_cron_tz — Automation cron timezone 정합 (v2.1.0 C5 stub)', () => {
+  test('DACT-1 — cron 9AM 시스템 TZ fire', async () => {
+    // TODO (v2.1.x): TZ override + fake timers + AutomationManager.fire 검증
+  });
+
+  test('DACT-2 — settings timezone override 반영', async () => {
+    // TODO: settings 의 timezone field (없으면 system) 적용
+  });
+
+  test('DACT-3 — DST spring-forward 시 02:30 cron 이동', async () => {
+    // TODO: 시스템 TZ=US/Eastern + 2026-03-08 fixture
+  });
+
+  test('DACT-4 — DST fall-back 시 01:30 한 번만 fire', async () => {
+    // TODO: 시스템 TZ=US/Eastern + 2026-11-01 fixture
+  });
+
+  test('DACT-5 — system TZ 런타임 변경 시 next-fire 재평가', async () => {
+    // TODO: process.env.TZ 변경 + AutomationManager refresh
+  });
+});

--- a/e2e/_drive_mcp_manifest_reject.spec.ts
+++ b/e2e/_drive_mcp_manifest_reject.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * drive_mcp_manifest_reject — MCP plugin manifest 거부 시나리오 (v2.1.0 C5 stub).
+ *
+ * Spec: docs/v2.x-roadmap.md (Phase C C5 — e2e regression sweep).
+ * Status: STUB — 시나리오 정의 + skip annotation. 실제 implementation 은
+ * v2.1.x 후속 슬롯.
+ *
+ * 목적
+ * ────────────
+ * MCP server / Plugin 의 manifest 가 invalid (schema 위반, capability 미정의,
+ * version mismatch, signature invalid 등) 시 사용자에게 명확한 거부 메시지
+ * 표시 + 그 manifest 가 절대 로드 안 되는지 (fail-closed) 회귀 lock.
+ *
+ * 시나리오 (구현 시 활성):
+ *   - DMR-1: MCP server manifest 의 required field 누락 → 사용자 toast +
+ *            mcpManager.list() 에 안 보임
+ *   - DMR-2: Plugin manifest 의 capability 가 ALL_CAPABILITIES 외 → 거부
+ *   - DMR-3: Plugin signature invalid (v2.0.0+ B5 옵션) → 거부
+ *   - DMR-4: 거부된 manifest 가 settings UI 의 plugin 리스트에 안 나타남
+ *   - DMR-5: 같은 manifest 를 두 번 install 시도 → 두 번째도 동일하게 거부
+ *
+ * 인프라 요구사항:
+ *   - tests/fixtures/mcp/invalid-X.json 시나리오 fixture
+ *   - tests/fixtures/plugins/invalid-X/ malformed manifest dir
+ *   - PluginManager / McpManager 의 audit emit 검증 (audit_log 'rejected' event)
+ */
+
+import { test } from './fixtures';
+
+test.describe.skip('drive_mcp_manifest_reject — MCP / Plugin manifest 거부 시나리오 (v2.1.0 C5 stub)', () => {
+  test('DMR-1 — MCP server manifest required field 누락 → 거부 + 사용자 toast', async () => {
+    // TODO (v2.1.x): malformed mcp manifest fixture + UI assertion
+  });
+
+  test('DMR-2 — Plugin manifest capability 미정의 → 거부', async () => {
+    // TODO: malformed plugin manifest + PluginManager.scan 결과 검증
+  });
+
+  test('DMR-3 — Plugin signature invalid (v2.0.0+ B5) → 거부', async () => {
+    // TODO: B5 signed manifest 검증 옵션 land 후 활성
+  });
+
+  test('DMR-4 — 거부된 manifest 가 settings UI 에 안 나타남', async () => {
+    // TODO: PluginsModal / McpSettings 의 list 검증
+  });
+
+  test('DMR-5 — 동일 invalid manifest 두 번째 install 도 거부', async () => {
+    // TODO: idempotent rejection 검증
+  });
+});

--- a/e2e/_drive_preview_annotation.spec.ts
+++ b/e2e/_drive_preview_annotation.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * drive_preview_annotation — PreviewPanel annotation visual diff (v2.1.0 C5 stub).
+ *
+ * Spec: docs/v2.x-roadmap.md (Phase C C5 — e2e regression sweep).
+ * Status: STUB — 시나리오 정의 + skip annotation. 실제 implementation 은
+ * v2.1.x 후속 슬롯에서 visual baseline 캡처 + screenshot diff 도입.
+ *
+ * 목적
+ * ────────────
+ * PreviewPanel 의 annotation overlay (사용자가 preview 위에 그리는 주석/
+ * highlight) 가 layout 변경 / theme switch / zoom 후에도 정확한 위치에
+ * 유지되는지 visual regression 으로 확인.
+ *
+ * 시나리오 (구현 시 활성):
+ *   - DPA-1: annotation 그리기 → screenshot baseline
+ *   - DPA-2: window resize 후 annotation 위치 보존 (zoom-aware)
+ *   - DPA-3: theme dark→light 전환 후 annotation 색 contrast OK
+ *   - DPA-4: annotation export → 다른 환경에서 import → 위치 정합
+ *
+ * 인프라 요구사항 (v2.1.x):
+ *   - Playwright `toMatchSnapshot` 활성 + .png 저장소
+ *   - PreviewPanel 의 annotation API testid (`preview-annotation-overlay`)
+ *   - DPI / OS-platform 별 baseline 분기
+ */
+
+import { test } from './fixtures';
+
+test.describe.skip('drive_preview_annotation — PreviewPanel annotation visual diff (v2.1.0 C5 stub)', () => {
+  test('DPA-1 — annotation 그리기 → baseline screenshot', async () => {
+    // TODO (v2.1.x): annotation API + screenshot capture
+  });
+
+  test('DPA-2 — window resize 후 위치 보존', async () => {
+    // TODO: zoom + resize matrix
+  });
+
+  test('DPA-3 — theme switch 후 contrast', async () => {
+    // TODO: data-theme=light/dark 전환 후 axe + visual diff
+  });
+
+  test('DPA-4 — annotation export/import round-trip', async () => {
+    // TODO: settings UI 의 export → 새 session import → 위치 검증
+  });
+});


### PR DESCRIPTION
## Summary

v2.1.0 Phase C C5. PRD 의 3 영역 e2e regression scenario 를 `test.describe.skip` 으로 lock — 시나리오 정의 + acceptance criteria. 실제 impl 은 v2.1.x 후속 슬롯.

## Changes

| File | LOC | Cases |
|---|---|---|
| `e2e/_drive_preview_annotation.spec.ts` | +35 | DPA-1~4 (visual diff) |
| `e2e/_drive_mcp_manifest_reject.spec.ts` | +44 | DMR-1~5 (manifest 거부) |
| `e2e/_drive_automation_cron_tz.spec.ts` | +43 | DACT-1~5 (cron timezone) |

## Why scaffolds (not full impl)

각 시나리오 별 인프라 요구사항이 다름:
- **DPA**: Playwright `toMatchSnapshot` baseline + DPI/OS 분기
- **DMR**: malformed manifest fixture 디렉토리 (mcp + plugin 양쪽)
- **DACT**: process.env.TZ override + fake timers + AutomationManager fire history IPC

각 인프라 슬롯이 v2.1.x 별도 PR 로 들어갈 예정. 본 PR 은 시나리오 lock + TODO 명시.

## Verification

- `test.describe.skip` 이라 e2e CI 에서 자동 skip — 회귀 0
- 0 TS errors
- prettier clean

## Follow-ups (v2.1.x)

각 stub 파일의 TODO 마다 별 슬롯 — Visual baseline 인프라, malformed manifest fixtures, TZ override 인프라.

🤖 Generated with [Claude Code](https://claude.com/claude-code)