### PR TITLE
feat(security): A2 wiring — parsePermissionRequest at IPC boundary

### DIFF
--- a/src/main/IpcPermissionConfirmer.ts
+++ b/src/main/IpcPermissionConfirmer.ts
@@ -25,6 +25,7 @@ import type {
   PermissionResponse,
   PermissionGrantDuration,
 } from '@/tools';
+import { parsePermissionRequest } from '../tools/permissionRequestSchema';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
@@ -64,8 +65,20 @@ export class IpcPermissionConfirmer implements PermissionConfirmer {
 
   /**
    * Queue 가 호출. PermissionRequest 를 renderer 로 송신 + Promise 반환.
+   *
+   * v2.x (A2 wiring) — IPC boundary 에서 parsePermissionRequest 로 fail-closed
+   * validation. malformed request (caller bug or future schema drift) 시 즉시
+   * deny — renderer 에 잘못된 shape 가 새지 않음. parse 통과 시 원본 request
+   * 그대로 전송 (caller 가 expectations 유지).
    */
   async confirm(request: PermissionRequest): Promise<PermissionResponse> {
+    const parsed = parsePermissionRequest(request);
+    if (parsed === null) {
+      console.error(
+        `[IpcPermissionConfirmer] parsePermissionRequest fail — malformed request rejected (id=${request.request_id})`
+      );
+      return { request_id: request.request_id, decision: 'deny' };
+    }
     return new Promise<PermissionResponse>((resolve) => {
       const timeoutHandle = setTimeout(() => {
         if (!this.pending.has(request.request_id)) return;

--- a/tests/main/IpcPermissionConfirmer.test.ts
+++ b/tests/main/IpcPermissionConfirmer.test.ts
@@ -16,10 +16,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { IpcPermissionConfirmer } from '../../src/main/IpcPermissionConfirmer';
 import type { PermissionRequest } from '../../src/tools';
 
+// v2.x (A2 wiring): session_id 는 UUIDv7 강제 (PermissionRequestSchema).
+// 본 fixture 의 session_id 는 valid UUIDv7 — IPC boundary parse 통과 위함.
+const VALID_SESSION_ID = '01890c1c-9c47-7a3f-bf24-aabbccddeeff';
+
 function sampleRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
   return {
     request_id: 'req-1',
-    session_id: 's1' as PermissionRequest['session_id'],
+    session_id: VALID_SESSION_ID as PermissionRequest['session_id'],
     turn_id: 't1' as PermissionRequest['turn_id'],
     call_id: 'c1' as PermissionRequest['call_id'],
     tool_id: 'mock.tool',
@@ -103,6 +107,40 @@ describe('IpcPermissionConfirmer', () => {
     });
     const matched = confirmer.respond('non-existent', 'once');
     expect(matched).toBe(false);
+  });
+
+  // v2.x (A2 wiring): IPC boundary parsePermissionRequest fail-closed.
+  it('malformed request (invalid session_id) → 즉시 deny + send X (fail-closed)', async () => {
+    const sendSpy = vi.fn().mockReturnValue(true);
+    const confirmer = new IpcPermissionConfirmer({
+      send: sendSpy,
+      timeout_ms: 1_000_000,
+    });
+    // session_id 가 UUIDv7 아님 (legacy 's1'). schema parse fail.
+    const malformed = sampleRequest({
+      request_id: 'malformed-1',
+      session_id: 's1' as PermissionRequest['session_id'],
+    });
+    const response = await confirmer.confirm(malformed);
+    expect(response.decision).toBe('deny');
+    expect(response.request_id).toBe('malformed-1');
+    // send 가 호출되지 않았음 — renderer 에 잘못된 shape 안 새는지 검증.
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('malformed request (target.kind invalid) → 즉시 deny', async () => {
+    const sendSpy = vi.fn().mockReturnValue(true);
+    const confirmer = new IpcPermissionConfirmer({
+      send: sendSpy,
+      timeout_ms: 1_000_000,
+    });
+    const malformed = sampleRequest({
+      request_id: 'malformed-2',
+      target: { kind: 'badkind' as 'path', value: '/tmp' },
+    });
+    const response = await confirmer.confirm(malformed);
+    expect(response.decision).toBe('deny');
+    expect(sendSpy).not.toHaveBeenCalled();
   });
 
   it('drainAllAsDeny — 모든 pending deny', async () => {


### PR DESCRIPTION
## Summary

A2 (deferred from Phase A → v2.0.0) 의 wiring 부분 land. PermissionRequestSchema 가 IPC boundary 에서 fail-closed validation 으로 활성화.

## Changes

| File | Change |
|---|---|
| `src/main/IpcPermissionConfirmer.ts` | confirm() 진입 시 parsePermissionRequest → null 이면 즉시 deny |
| `tests/main/IpcPermissionConfirmer.test.ts` | fixture session_id UUIDv7 + 2 fail-closed 케이스 |

## Behavior

- **valid request**: 기존 동작 그대로 — send + pending 등록
- **malformed (invalid session_id / target.kind 등)**:
  - `console.error` 로 alert
  - **send 호출 X** (renderer 에 잘못된 shape 안 새지)
  - 즉시 `{ decision: 'deny' }` return

## Verification

- 15/15 vitest (13 existing + 2 new fail-closed)
- typecheck 0
- prettier clean

## Note on 11 consumer files type narrow

PRD US-104 의 "11 consumer files type narrow" 부분은 variants uniform shape 라 type narrowing 가치 minimal — defer 유지. 본 PR 은 **schema 의 runtime 효력 확보** 핵심 (security gain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)