### PR TITLE
feat(plugins): default isolation_mode = utility_process (ADR-0003 v2.2.0 timeline)

### DIFF
--- a/docs/adr/0003-plugin-utility-process-isolation.md
+++ b/docs/adr/0003-plugin-utility-process-isolation.md
@@ -68,8 +68,9 @@ R-A1 risk register: "utility_process 격리가 plugin API breaking change
 | 시점 | default `isolation_mode` | 의미 |
 |------|--------------------------|------|
 | v2.0.0 | `in_process` (legacy 호환) | utility_process 는 explicit opt-in |
-| v2.1.0 | `utility_process` (default) | in_process 는 explicit opt-out |
-| v2.2.0+ | `utility_process` only | in_process path 제거 |
+| v2.1.0 | `in_process` (default) | utility_process 는 explicit opt-in (timeline 연기) |
+| v2.2.0 | `utility_process` (default) | in_process 는 explicit opt-out (`DREAMPIA_PLUGIN_ISOLATION=in_process`) |
+| v2.3.0+ | `utility_process` only | in_process path 제거 |
 
 env override: `DREAMPIA_PLUGIN_ISOLATION=utility_process|in_process`.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -444,10 +444,12 @@ app.whenReady().then(async () => {
   // v1.6.5 — Plugin Hook runtime. ai/start-stream 의 pre/post_turn 호출용.
   // v1.1.6 (D1): gate wired — manifest.capabilities 미승인 시 hook skip.
   // v2.0.0 (B2): isolation_mode 옵션 — env DREAMPIA_PLUGIN_ISOLATION 으로
-  //   utility_process 활성화. default in_process (기존 vm.createContext).
-  //   ADR-0003 가 v2.1.0 에서 default 전환 timeline 명시.
+  //   utility_process 활성화. v2.0.0 default = in_process.
+  // v2.2.0+ (ADR-0003 migration timeline): default = utility_process. legacy
+  //   in_process 는 explicit opt-out (`DREAMPIA_PLUGIN_ISOLATION=in_process`).
+  //   v2.x.x 후속에서 in_process path 제거 예정.
   const pluginIsolation = process.env.DREAMPIA_PLUGIN_ISOLATION;
-  const useUtilityProcess = pluginIsolation === 'utility_process';
+  const useUtilityProcess = pluginIsolation !== 'in_process';
   const pluginAuditSink = (
     event: import('./plugins/PluginHookRunner').PluginHookAuditEvent
   ): void => {


### PR DESCRIPTION
## Summary

ADR-0003 migration timeline 적용. Plugin 격리 default 가 `in_process` → `utility_process` 로 전환. legacy 는 explicit opt-out.

## Changes

| File | Change |
|---|---|
| `src/main/index.ts` | `useUtilityProcess = pluginIsolation !== 'in_process'` (조건 반전) |
| `docs/adr/0003-plugin-utility-process-isolation.md` | Timeline 갱신 (v2.2.0 전환, v2.3.0+ removal) |

## Behavior matrix

| `DREAMPIA_PLUGIN_ISOLATION` | v2.0.0/v2.1.0 (이전) | v2.2.0+ (이 PR) |
|---|---|---|
| 미설정 | in_process | **utility_process** |
| `utility_process` | utility_process | utility_process |
| `in_process` | in_process | in_process |
| 다른 값 | in_process | utility_process |

## Risk

dist/main/plugins/pluginWorkerEntry.js 가 빌드에 포함되어야 utility_process 가 fork 가능. CI E2E 가 검증 (e2e 가 plugin hook 실행하면 새 default 활성).

## Test plan

- [ ] CI: Lint, TS, Test ×3, Build ×3, E2E green
- [ ] 기존 plugin 시나리오 회귀 0 (env=in_process 강제 시 legacy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)