### PR TITLE
feat(v2.3.0 phase 1): foundation types + McpCapabilityGate + preload surface

### DIFF
--- a/docs/migration/v2.2-to-v2.3.md
+++ b/docs/migration/v2.2-to-v2.3.md
@@ -1,0 +1,99 @@
+# Migration: v2.2.0 → v2.3.0
+
+> **Status**: Skeleton — sections to be finalized in Phase 7 (US-700) of v2.3.0.
+> **Source plan**: [.omc/plans/v2.3.0-plugin-ga.md](../../.omc/plans/v2.3.0-plugin-ga.md)
+> **Theme**: Plugin GA — utility_process default, signed marketplace, MCP capability negotiation, full event stream.
+
+This guide describes user-visible changes between v2.2.0 (architectural foundations release) and v2.3.0 (Plugin GA release). Most changes are additive; the one notable default flip is plugin isolation mode.
+
+---
+
+## 1. Plugin Isolation Default Flip (PR #33 redo)
+
+**TODO (Phase 7)**: Document the default change from `in_process` (v2.2.0) → `utility_process` (v2.3.0). Cover:
+
+- New settings field `pluginIsolationMode: 'in_process' | 'utility_process' | 'auto'` (default `utility_process`).
+- Per-plugin override `plugins.<id>.isolationMode` (G6 resolution).
+- First-run migration toast text and dismiss behavior.
+- Telemetry: 3-event hook (spawn / exit / error) + first-failure consent prompt.
+- Backward compat: env `DREAMPIA_PLUGIN_ISOLATION` still honored as override.
+- What plugin authors should test: `requires_native_modules: true` plugins must declare `preferred_isolation: 'in_process'` in manifest runtime block, otherwise utility_process spawn will fail and trigger consent prompt.
+- Hard-fail behavior in `strict` mode (no silent fallback) — link to G4 decision in plan.
+
+## 2. MCP Manifest Verification (Sigstore)
+
+**TODO (Phase 7)**: Document the new MCP marketplace verification surface. Cover:
+
+- New settings field `mcpVerificationMode: 'strict' | 'warn' | 'off'` (default `strict`).
+- Identity policy enforcement: `signing.identity.issuer` + `signing.identity.subject_pattern` must match Sigstore cert claims.
+- Behavior in each mode:
+  - `strict`: identity_mismatch / signature_invalid / unsigned-no-bundle = reject install.
+  - `warn`: same conditions = audit-warn-allow.
+  - `off`: skip verification entirely (record stays `verification_status='unverified'`).
+- Bundled TUF root + Fulcio cert chain refresh policy (only via electron-updater, not runtime fetch).
+- Air-gap behavior: offline + signed manifest with bundled inclusion proof = allow in `strict`; without bundle = block.
+- Marketplace UI: verification badge (verified / unverified / identity_mismatch / signature_invalid / revoked).
+
+## 3. Per-Plugin Isolation Override
+
+**TODO (Phase 7)**: Document the per-plugin override surface (G6 codex tightening). Cover:
+
+- Settings shape: `plugins.<plugin_id>.isolationMode` overrides global default.
+- `IsolationDowngradeModal` UX: warning text + plugin id type-in confirmation + audit log entry.
+- `isolationDowngradeConsent` ISO 8601 recording in settings.
+- Marketplace badge: "runs in main process" surfaced for any plugin with `isolationMode = 'in_process'`.
+- When to use: native modules requiring main-process API (Electron ABI, asar unpacking, mac unsigned library loading, Windows AV interactions) — link to plan §10 G6 codex hidden gotchas.
+
+## 4. Signed Revocation Feed
+
+**TODO (Phase 7)**: Document the signed revocation feed (G3 codex tightening). Cover:
+
+- Feed location: `revocations/feed.json` + `revocations/feed.json.sigstore` in registry repo.
+- Polling cadence: on app start + every 6h while running + manual `Check for plugin updates` action.
+- Feed schema: monotonic `feed_version`, `max_age`, entry `{package_id, publisher_id, version, artifact_digest, manifest_digest, reason, since}`.
+- Rollback rejection: app refuses any feed with `feed_version` < locally-cached last-known-good (rollback attack defense).
+- User-visible toast on new revocation; UI badge updates in marketplace.
+- Stale feed (`max_age` exceeded with no fresh fetch) = `revocation_status='unknown'` — treated as fail-closed in `strict` mcpVerificationMode.
+
+## 5. Schema Changes (settings + persisted)
+
+**TODO (Phase 7)**: Enumerate schema migrations.
+
+- Settings additions:
+  - `pluginIsolationMode: 'in_process' | 'utility_process' | 'auto'`
+  - `mcpVerificationMode: 'strict' | 'warn' | 'off'`
+  - `plugins.<id>.isolationMode` (per-plugin override)
+  - `plugins.<id>.isolationDowngradeConsent` (ISO 8601, recorded on user confirm)
+- Persisted artifacts:
+  - `~/.dreampia/mcp-grants/<server_id>/granted.json` (mirrors plugin-grants pattern)
+  - `~/.dreampia/installed-plugin-records/<package_id>.json` (single-source-of-truth record per US-100)
+- Backward compat: existing `~/.dreampia/plugin-grants/` schema unchanged.
+
+## 6. Removed / Deprecated
+
+**TODO (Phase 7)**: Currently empty (v2.3.0 is additive). Capture any legacy paths or settings deprecated by Phase 7 review.
+
+## 7. Plugin Author Action Items
+
+**TODO (Phase 7)**: Concrete checklist for plugin authors:
+
+- [ ] Add `signing` block to manifest if planning to publish via marketplace.
+- [ ] Set `runtime.requires_native_modules` truthfully — affects user's isolation downgrade UX.
+- [ ] Set `runtime.preferred_isolation` if plugin needs main-process API.
+- [ ] Verify plugin runs cleanly in `utility_process` mode locally before publishing.
+- [ ] Sign artifact via GitHub Actions Sigstore-keyless workflow (sample workflow in [TODO link]).
+
+---
+
+## Roll-back Path
+
+**TODO (Phase 7)**: Document escape hatches:
+
+- Env `DREAMPIA_DISABLE_SIGSTORE=1` → skip verify (debug only, audit-warn).
+- `mcpVerificationMode = 'off'` → skip verify (settings UI).
+- Feature flag `~/.dreampia/feature-flags.json` → `enableMcpMarketplace: false` (kill switch if registry compromised).
+- electron-updater channel for hot-patch of verify code path.
+
+---
+
+*This skeleton was created during Phase 1 (US-105). Final content is Phase 7 (US-700) work after all preceding phases land.*

--- a/src/main/mcp/McpCapabilityGate.ts
+++ b/src/main/mcp/McpCapabilityGate.ts
@@ -21,7 +21,15 @@
  *   - InstalledPluginRecord materialization (caller composes manifest+verify result).
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 const GRANTED_FILENAME = 'granted.json';
@@ -68,7 +76,9 @@ export class McpCapabilityGate {
       options.auditSink ??
       ((e): void => {
         if (e.event !== 'mcp.cap_granted') {
-          console.warn(`[McpCapabilityGate] ${e.event} ${e.server_id}/${e.capability ?? '*'} epoch=${e.grant_epoch}`);
+          console.warn(
+            `[McpCapabilityGate] ${e.event} ${e.server_id}/${e.capability ?? '*'} epoch=${e.grant_epoch}`
+          );
         }
       });
     if (this.storageDir !== undefined) {
@@ -104,9 +114,10 @@ export class McpCapabilityGate {
         if (parsed === null || typeof parsed !== 'object') continue;
         const obj = parsed as Record<string, unknown>;
         if (!Array.isArray(obj['capabilities'])) continue;
-        if (typeof obj['grant_epoch'] !== 'number' || !Number.isFinite(obj['grant_epoch'])) continue;
+        if (typeof obj['grant_epoch'] !== 'number' || !Number.isFinite(obj['grant_epoch']))
+          continue;
         const caps = obj['capabilities'].filter(
-          (x): x is string => typeof x === 'string' && x.length > 0,
+          (x): x is string => typeof x === 'string' && x.length > 0
         );
         this.state.set(entry, {
           capabilities: new Set(caps),

--- a/src/main/mcp/McpCapabilityGate.ts
+++ b/src/main/mcp/McpCapabilityGate.ts
@@ -1,0 +1,240 @@
+/**
+ * McpCapabilityGate — manifest-level capability grants for installed MCP servers.
+ *
+ * Spec: .omc/plans/v2.3.0-plugin-ga.md §4 Phase 1.2 (US-102), gate G5.
+ *
+ * Mirrors `PluginCapabilityGate`'s persistence shape (`<dir>/<id>/granted.json`)
+ * but operates per-MCP-server-id rather than per-plugin-name. Distinct module
+ * because MCP servers and plugins have different identity models (server_id is
+ * user-provided slug; plugin_name is package-derived).
+ *
+ * v2.3.0-specific addition: **grant_epoch monotonic counter** per server.
+ *   - Incremented synchronously on every revoke (single-cap or all).
+ *   - Read by hostBridge dispatcher (US-403) on each in-flight RPC to detect
+ *     "grant invalidated mid-call" race. This closes G5 codex re-emphasis:
+ *     "already-posted parentPort messages cannot be recalled, so revoke must
+ *     synchronously invalidate dispatcher grants".
+ *
+ * What this module does NOT do (deferred to Phase 2/3):
+ *   - User consent UX (relies on `conflictResolver` + caller-driven prompt flow).
+ *   - Sigstore verify (Phase 2.2 / US-201).
+ *   - InstalledPluginRecord materialization (caller composes manifest+verify result).
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const GRANTED_FILENAME = 'granted.json';
+
+export interface McpGrantedFileShape {
+  /** Persisted capabilities for this server. Sorted on write. */
+  capabilities: string[];
+  /** Monotonic counter persisted across restarts. Bumped on every revoke. */
+  grant_epoch: number;
+}
+
+export interface McpCapabilityAuditEvent {
+  timestamp: string;
+  event: 'mcp.cap_granted' | 'mcp.cap_revoked' | 'mcp.cap_revoked_all';
+  server_id: string;
+  capability?: string;
+  grant_epoch: number;
+}
+
+export interface McpCapabilityGateOptions {
+  /**
+   * Directory for `<server_id>/granted.json`. Production wires
+   * `path.join(app.getPath('userData'), 'mcp-grants')` (or
+   * `~/.dreampia/mcp-grants/`). Undefined = in-memory only.
+   */
+  storageDir?: string;
+  /** Audit hook. Default: console.warn on revoke events. */
+  auditSink?: (event: McpCapabilityAuditEvent) => void;
+}
+
+interface ServerState {
+  capabilities: Set<string>;
+  grant_epoch: number;
+}
+
+export class McpCapabilityGate {
+  private readonly storageDir: string | undefined;
+  private readonly auditSink: (event: McpCapabilityAuditEvent) => void;
+  private readonly state = new Map<string, ServerState>();
+
+  constructor(options: McpCapabilityGateOptions = {}) {
+    this.storageDir = options.storageDir;
+    this.auditSink =
+      options.auditSink ??
+      ((e): void => {
+        if (e.event !== 'mcp.cap_granted') {
+          console.warn(`[McpCapabilityGate] ${e.event} ${e.server_id}/${e.capability ?? '*'} epoch=${e.grant_epoch}`);
+        }
+      });
+    if (this.storageDir !== undefined) {
+      this.loadAllPersisted(this.storageDir);
+    }
+  }
+
+  /**
+   * Load every `<storageDir>/<server_id>/granted.json` into in-memory state.
+   * Corrupt JSON / missing capabilities array / non-numeric epoch are silently
+   * skipped (treated as "no grant"). Same forgiving policy as PluginCapabilityGate
+   * — fresh state recovers on next legitimate grant.
+   */
+  private loadAllPersisted(dir: string): void {
+    if (!existsSync(dir)) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const serverDir = join(dir, entry);
+      try {
+        if (!statSync(serverDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      const file = join(serverDir, GRANTED_FILENAME);
+      if (!existsSync(file)) continue;
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(file, 'utf-8'));
+        if (parsed === null || typeof parsed !== 'object') continue;
+        const obj = parsed as Record<string, unknown>;
+        if (!Array.isArray(obj['capabilities'])) continue;
+        if (typeof obj['grant_epoch'] !== 'number' || !Number.isFinite(obj['grant_epoch'])) continue;
+        const caps = obj['capabilities'].filter(
+          (x): x is string => typeof x === 'string' && x.length > 0,
+        );
+        this.state.set(entry, {
+          capabilities: new Set(caps),
+          grant_epoch: obj['grant_epoch'],
+        });
+      } catch {
+        // corrupt → skip
+      }
+    }
+  }
+
+  private getOrInitState(server_id: string): ServerState {
+    let s = this.state.get(server_id);
+    if (s === undefined) {
+      s = { capabilities: new Set(), grant_epoch: 0 };
+      this.state.set(server_id, s);
+    }
+    return s;
+  }
+
+  private writePersisted(server_id: string, s: ServerState): void {
+    if (this.storageDir === undefined) return;
+    const serverDir = join(this.storageDir, server_id);
+    if (s.capabilities.size === 0) {
+      // Empty capability set — keep file (preserves grant_epoch monotonicity even
+      // if the user revokes everything; bumping epoch for a bystander-grant flow
+      // matters more than file cleanup). Caller can `clearAll` to delete.
+    }
+    try {
+      mkdirSync(serverDir, { recursive: true });
+      const data: McpGrantedFileShape = {
+        capabilities: Array.from(s.capabilities).sort(),
+        grant_epoch: s.grant_epoch,
+      };
+      writeFileSync(join(serverDir, GRANTED_FILENAME), JSON.stringify(data, null, 2), 'utf-8');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[McpCapabilityGate] persist failed for ${server_id}: ${msg}`);
+    }
+  }
+
+  private deletePersistedFile(server_id: string): void {
+    if (this.storageDir === undefined) return;
+    const file = join(this.storageDir, server_id, GRANTED_FILENAME);
+    if (!existsSync(file)) return;
+    try {
+      unlinkSync(file);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[McpCapabilityGate] delete failed for ${server_id}: ${msg}`);
+    }
+  }
+
+  /**
+   * Grant a single capability synchronously. Persists if storageDir set.
+   * Idempotent — granting an already-granted cap is a no-op (no epoch bump).
+   *
+   * Note: this method assumes user consent has already been obtained upstream
+   * (via `conflictResolver` + caller-driven prompt). It does NOT prompt.
+   */
+  grantOne(server_id: string, capability: string): void {
+    const s = this.getOrInitState(server_id);
+    if (s.capabilities.has(capability)) return;
+    s.capabilities.add(capability);
+    this.writePersisted(server_id, s);
+    this.auditSink({
+      timestamp: new Date().toISOString(),
+      event: 'mcp.cap_granted',
+      server_id,
+      capability,
+      grant_epoch: s.grant_epoch,
+    });
+  }
+
+  /**
+   * Revoke a single capability — or pass undefined to revoke all for this server.
+   *
+   * **G5 invariant**: grant_epoch is incremented synchronously here, BEFORE this
+   * method returns. The hostBridge dispatcher reads grant_epoch on every in-flight
+   * RPC; any RPC issued under a stale epoch is aborted. This closes the
+   * "already-posted parentPort message cannot be recalled" race.
+   *
+   * Idempotent in the no-op sense — revoking an ungranted capability still bumps
+   * the epoch (caller may rely on monotonic ordering).
+   */
+  revokeOne(server_id: string, capability?: string): number {
+    const s = this.getOrInitState(server_id);
+    s.grant_epoch += 1;
+    if (capability === undefined) {
+      s.capabilities.clear();
+      this.deletePersistedFile(server_id);
+      this.auditSink({
+        timestamp: new Date().toISOString(),
+        event: 'mcp.cap_revoked_all',
+        server_id,
+        grant_epoch: s.grant_epoch,
+      });
+      return s.grant_epoch;
+    }
+    s.capabilities.delete(capability);
+    this.writePersisted(server_id, s);
+    this.auditSink({
+      timestamp: new Date().toISOString(),
+      event: 'mcp.cap_revoked',
+      server_id,
+      capability,
+      grant_epoch: s.grant_epoch,
+    });
+    return s.grant_epoch;
+  }
+
+  isGranted(server_id: string, capability: string): boolean {
+    return this.state.get(server_id)?.capabilities.has(capability) === true;
+  }
+
+  listGranted(server_id: string): string[] {
+    const s = this.state.get(server_id);
+    if (s === undefined) return [];
+    return Array.from(s.capabilities).sort();
+  }
+
+  /** Read current grant_epoch for a server. Used by dispatcher per-call check (US-403). */
+  getGrantEpoch(server_id: string): number {
+    return this.state.get(server_id)?.grant_epoch ?? 0;
+  }
+
+  /** Test/shutdown — clear all in-memory state. File persistence preserved. */
+  clearAll(): void {
+    this.state.clear();
+  }
+}

--- a/src/main/mcp/conflictResolver.ts
+++ b/src/main/mcp/conflictResolver.ts
@@ -1,0 +1,62 @@
+/**
+ * conflictResolver — decide how to handle an MCP capability request given the
+ * already-granted set for that server.
+ *
+ * Spec: .omc/plans/v2.3.0-plugin-ga.md §4 Phase 1.3 (US-103).
+ *
+ * Decision matrix (G6 spirit — minimum-surprise):
+ *   - All requested already granted → allow (no prompt).
+ *   - Any requested capability is in DENY list (host policy) → deny.
+ *   - Any requested capability NOT yet granted (and not denied) → requires_user_consent.
+ *
+ * Forbidden (deny) capabilities are policy-controlled host-side; v2.3.0 ships
+ * with an empty deny set but the structure is here so future ADRs can populate
+ * (e.g., a malicious-publisher revocation may add `host.fs.write` to the deny
+ * set for that publisher's servers).
+ */
+
+export type CapabilityConflictDecision =
+  | { kind: 'allow'; reason: 'superset_granted' }
+  | { kind: 'deny'; reason: string; offending: readonly string[] }
+  | { kind: 'requires_user_consent'; reason: string; new_capabilities: readonly string[] };
+
+export interface CapabilityConflictPolicy {
+  /** Capabilities that this caller may NEVER grant. Empty by default v2.3.0. */
+  readonly deniedCapabilities?: ReadonlySet<string>;
+}
+
+/**
+ * Decide outcome for a request.
+ *
+ * @param requested capability set the manifest declares (or runtime requests)
+ * @param currentGranted capability set already approved for this server
+ * @param policy optional deny-list policy
+ */
+export function resolveCapabilityConflict(
+  requested: readonly string[],
+  currentGranted: readonly string[],
+  policy: CapabilityConflictPolicy = {},
+): CapabilityConflictDecision {
+  const granted = new Set(currentGranted);
+  const denied = policy.deniedCapabilities ?? new Set<string>();
+
+  const denyOffenders = requested.filter((c) => denied.has(c));
+  if (denyOffenders.length > 0) {
+    return {
+      kind: 'deny',
+      reason: 'capability in host deny list',
+      offending: denyOffenders,
+    };
+  }
+
+  const newCaps = requested.filter((c) => !granted.has(c));
+  if (newCaps.length === 0) {
+    return { kind: 'allow', reason: 'superset_granted' };
+  }
+
+  return {
+    kind: 'requires_user_consent',
+    reason: 'one or more capabilities not previously granted',
+    new_capabilities: newCaps,
+  };
+}

--- a/src/main/mcp/conflictResolver.ts
+++ b/src/main/mcp/conflictResolver.ts
@@ -35,7 +35,7 @@ export interface CapabilityConflictPolicy {
 export function resolveCapabilityConflict(
   requested: readonly string[],
   currentGranted: readonly string[],
-  policy: CapabilityConflictPolicy = {},
+  policy: CapabilityConflictPolicy = {}
 ): CapabilityConflictDecision {
   const granted = new Set(currentGranted);
   const denied = policy.deniedCapabilities ?? new Set<string>();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1302,7 +1302,9 @@ const api = {
      * confirm, etc.). Returns null if no record matches.
      */
     getRecord: (package_id: string): Promise<Result<InstalledPluginRecord | null>> =>
-      ipcRenderer.invoke('mcp/get-record', package_id) as Promise<Result<InstalledPluginRecord | null>>,
+      ipcRenderer.invoke('mcp/get-record', package_id) as Promise<
+        Result<InstalledPluginRecord | null>
+      >,
 
     /**
      * v2.3.0 (US-104) — user-initiated revoke from Marketplace UI. Main process
@@ -1311,15 +1313,21 @@ const api = {
      * so renderer can update local cache without a follow-up listInstalled poll.
      */
     requestRevoke: (server_id: string): Promise<Result<{ grant_epoch: number }>> =>
-      ipcRenderer.invoke('mcp/request-revoke', server_id) as Promise<Result<{ grant_epoch: number }>>,
+      ipcRenderer.invoke('mcp/request-revoke', server_id) as Promise<
+        Result<{ grant_epoch: number }>
+      >,
 
     /**
      * v2.3.0 (US-104) — user-initiated revocation feed refresh ("Check for
      * plugin updates" button). Triggers `signedRevocationFeed.poll({ manual: true })`
      * out of band from the 6h schedule. Returns whether a new feed was applied.
      */
-    requestRefreshRevocations: (): Promise<Result<{ applied: boolean; feed_version: number | null }>> =>
-      ipcRenderer.invoke('mcp/request-refresh-revocations') as Promise<Result<{ applied: boolean; feed_version: number | null }>>,
+    requestRefreshRevocations: (): Promise<
+      Result<{ applied: boolean; feed_version: number | null }>
+    > =>
+      ipcRenderer.invoke('mcp/request-refresh-revocations') as Promise<
+        Result<{ applied: boolean; feed_version: number | null }>
+      >,
   },
 
   /**

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -14,6 +14,8 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 import type { Session, SessionId, Turn } from '@/types';
+// v2.3.0 (US-104) — installed plugin record surface
+import type { InstalledPluginRecord } from '@/types/installedPluginRecord';
 import type {
   ConversationPatch,
   PermissionPatch,
@@ -570,6 +572,11 @@ const ALLOWED_INVOKE_CHANNELS = [
   'mcp/remove',
   'mcp/restart',
   'mcp/get-logs',
+  // v2.3.0 (US-104) — installed plugin record surface for marketplace UI
+  'mcp/list-installed',
+  'mcp/get-record',
+  'mcp/request-revoke',
+  'mcp/request-refresh-revocations',
   // v0.4.0 — usage / cost telemetry
   'usage/summary',
   'usage/daily',
@@ -1278,6 +1285,41 @@ const api = {
      */
     discover: (): Promise<Result<McpDiscoveryShape>> =>
       ipcRenderer.invoke('mcp/discover') as Promise<Result<McpDiscoveryShape>>,
+
+    /**
+     * v2.3.0 (US-104) — installed plugin record surface for Marketplace UI.
+     *
+     * Returns the cross-phase identity record for every installed MCP server.
+     * Spec: .omc/plans/v2.3.0-plugin-ga.md §3.1 AC-6.9 + §4 Phase 1.4.
+     * Reads from `~/.dreampia/installed-plugin-records/<package_id>.json` (main
+     * process). Renderer never touches disk directly.
+     */
+    listInstalled: (): Promise<Result<InstalledPluginRecord[]>> =>
+      ipcRenderer.invoke('mcp/list-installed') as Promise<Result<InstalledPluginRecord[]>>,
+
+    /**
+     * v2.3.0 (US-104) — fetch single record by package_id (refresh after revoke
+     * confirm, etc.). Returns null if no record matches.
+     */
+    getRecord: (package_id: string): Promise<Result<InstalledPluginRecord | null>> =>
+      ipcRenderer.invoke('mcp/get-record', package_id) as Promise<Result<InstalledPluginRecord | null>>,
+
+    /**
+     * v2.3.0 (US-104) — user-initiated revoke from Marketplace UI. Main process
+     * routes to `McpCapabilityGate.revokeOne(server_id)` (entire server) which
+     * synchronously bumps grant_epoch (G5) + persists. Returns the new epoch
+     * so renderer can update local cache without a follow-up listInstalled poll.
+     */
+    requestRevoke: (server_id: string): Promise<Result<{ grant_epoch: number }>> =>
+      ipcRenderer.invoke('mcp/request-revoke', server_id) as Promise<Result<{ grant_epoch: number }>>,
+
+    /**
+     * v2.3.0 (US-104) — user-initiated revocation feed refresh ("Check for
+     * plugin updates" button). Triggers `signedRevocationFeed.poll({ manual: true })`
+     * out of band from the 6h schedule. Returns whether a new feed was applied.
+     */
+    requestRefreshRevocations: (): Promise<Result<{ applied: boolean; feed_version: number | null }>> =>
+      ipcRenderer.invoke('mcp/request-refresh-revocations') as Promise<Result<{ applied: boolean; feed_version: number | null }>>,
   },
 
   /**

--- a/src/types/installedPluginRecord.ts
+++ b/src/types/installedPluginRecord.ts
@@ -1,0 +1,134 @@
+/**
+ * InstalledPluginRecord — single source of truth for an installed plugin/MCP server's
+ * identity, verification state, revocation state, and isolation mode.
+ *
+ * Cross-phase invariant for v2.3.0 Plugin GA. Read by:
+ *   - Renderer marketplace UI (verification badge, runs-in-main-process badge)
+ *   - manifestVerify (writes verification_status + last_verified_at)
+ *   - signedRevocationFeed (writes revocation_status + last_revocation_check_at)
+ *   - hostBridge dispatcher (reads isolation_mode + grant_epoch from McpCapabilityGate)
+ *   - AuditLogStore (records identity transitions)
+ *
+ * Spec: .omc/plans/v2.3.0-plugin-ga.md §4 Phase 1.0 (US-100), gates G1/G2/G3/G4/G6.
+ *
+ * Invariants:
+ *   - artifact_digest / manifest_digest are sha256 hex (64 chars).
+ *   - version is semver (major.minor.patch[-prerelease][+build]).
+ *   - last_verified_at must be ≥ installed_at when verification_status != 'unverified'.
+ *   - last_revocation_check_at advances monotonically per record (rollback rejection
+ *     enforced by signedRevocationFeed using monotonic feed_version, not this field).
+ */
+
+import { z } from 'zod';
+import { ISO8601Schema } from './common';
+
+// ────────────────────────────────────────────────────────────
+// Sub-schemas
+// ────────────────────────────────────────────────────────────
+
+/** Hex sha256 digest. Lowercase, exactly 64 chars. */
+const Sha256HexSchema = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
+
+/**
+ * Semver version string. Permissive (matches semver.org BNF) but rejects empty
+ * and obviously invalid forms (e.g. "v1", "1.2", "latest"). zod's regex is
+ * sufficient — we do not pull semver lib here to keep this module dep-free.
+ */
+const SemverSchema = z
+  .string()
+  .regex(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
+    'Must be semver (e.g. 1.2.3 or 1.2.3-beta.1)',
+  );
+
+/**
+ * Package id — globally unique across registry. Allows scoped form (`@org/pkg`)
+ * and plain form (`pkg-name`). [a-zA-Z0-9_-] plus `/` and leading `@` only.
+ */
+const PackageIdSchema = z
+  .string()
+  .min(1)
+  .max(214)
+  .regex(/^(@[a-zA-Z0-9][a-zA-Z0-9_-]*\/)?[a-zA-Z0-9][a-zA-Z0-9_-]*$/, 'Invalid package id');
+
+/**
+ * Publisher id — derived from Sigstore signing identity (issuer + sub claim).
+ * Format: `<issuer-host>:<sub-claim>` (e.g. `token.actions.githubusercontent.com:repo:org/pkg:ref:refs/tags/v1.0.0`).
+ * Stored verbatim from cert claims; not validated structurally beyond non-empty +
+ * length cap to prevent accidental record bloat.
+ */
+const PublisherIdSchema = z.string().min(1).max(512);
+
+// ────────────────────────────────────────────────────────────
+// Enums
+// ────────────────────────────────────────────────────────────
+
+/**
+ * verification_status — outcome of last manifestVerify run for this record.
+ *
+ * - `unverified`: never verified (just installed, or verification disabled).
+ * - `verified`: signature + identity policy passed.
+ * - `identity_mismatch`: signature valid, but cert claims do not match
+ *   manifest.signing.identity (issuer/sub_pattern). G2 codex tightening — this
+ *   is the "signature without identity policy is theater" failure mode.
+ * - `signature_invalid`: Sigstore verify rejected the bundle.
+ * - `revoked`: superseded by revocation_status='revoked' from signedRevocationFeed;
+ *   kept here as a UI hint (show red badge regardless of which path produced it).
+ */
+export const VerificationStatusSchema = z.enum([
+  'unverified',
+  'verified',
+  'identity_mismatch',
+  'signature_invalid',
+  'revoked',
+]);
+export type VerificationStatus = z.infer<typeof VerificationStatusSchema>;
+
+/**
+ * revocation_status — outcome of last signedRevocationFeed poll for this record.
+ *
+ * - `clear`: feed checked, package not in revocation list.
+ * - `revoked`: feed contains entry matching this record's package_id +
+ *   publisher_id + version + artifact_digest.
+ * - `unknown`: feed never successfully fetched OR feed is stale (max_age exceeded).
+ *   In `strict` mcpVerificationMode this should be treated as fail-closed.
+ */
+export const RevocationStatusSchema = z.enum(['clear', 'revoked', 'unknown']);
+export type RevocationStatus = z.infer<typeof RevocationStatusSchema>;
+
+/**
+ * isolation_mode — per-plugin override for v2.3.0 PR #33 default flip (G6).
+ *
+ * - `utility_process`: runs in `utilityProcess.fork()` child (default for v2.3.0+).
+ * - `in_process`: runs in main process (legacy; downgrade requires explicit user
+ *   consent + audit + marketplace badge per G6 codex tightening).
+ * - `auto`: utility_process preferred; on first failed fork(), prompt user once
+ *   for consent before falling back to in_process. Recorded as
+ *   `isolationDowngradeConsent` in settings on confirm.
+ */
+export const IsolationModeSchema = z.enum(['utility_process', 'in_process', 'auto']);
+export type IsolationMode = z.infer<typeof IsolationModeSchema>;
+
+// ────────────────────────────────────────────────────────────
+// Main schema
+// ────────────────────────────────────────────────────────────
+
+export const InstalledPluginRecordSchema = z
+  .object({
+    package_id: PackageIdSchema,
+    publisher_id: PublisherIdSchema,
+    version: SemverSchema,
+    artifact_digest: Sha256HexSchema,
+    manifest_digest: Sha256HexSchema,
+    verification_status: VerificationStatusSchema,
+    revocation_status: RevocationStatusSchema,
+    isolation_mode: IsolationModeSchema,
+    installed_at: ISO8601Schema,
+    last_verified_at: ISO8601Schema.nullable(),
+    last_revocation_check_at: ISO8601Schema.nullable(),
+  })
+  .strict();
+
+export type InstalledPluginRecord = z.infer<typeof InstalledPluginRecordSchema>;

--- a/src/types/installedPluginRecord.ts
+++ b/src/types/installedPluginRecord.ts
@@ -27,9 +27,7 @@ import { ISO8601Schema } from './common';
 // ────────────────────────────────────────────────────────────
 
 /** Hex sha256 digest. Lowercase, exactly 64 chars. */
-const Sha256HexSchema = z
-  .string()
-  .regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
+const Sha256HexSchema = z.string().regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
 
 /**
  * Semver version string. Permissive (matches semver.org BNF) but rejects empty
@@ -40,7 +38,7 @@ const SemverSchema = z
   .string()
   .regex(
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
-    'Must be semver (e.g. 1.2.3 or 1.2.3-beta.1)',
+    'Must be semver (e.g. 1.2.3 or 1.2.3-beta.1)'
   );
 
 /**

--- a/src/types/mcpManifest.ts
+++ b/src/types/mcpManifest.ts
@@ -1,0 +1,244 @@
+/**
+ * McpManifest — declarative metadata for an installable MCP server.
+ *
+ * v2.3.0 introduces this manifest as the artifact a publisher signs (via Sigstore
+ * keyless OIDC) and a static registry references. Manifest is the *only* thing
+ * required to install + verify; the entrypoint is a separate artifact whose digest
+ * the manifest binds.
+ *
+ * Spec: .omc/plans/v2.3.0-plugin-ga.md §4 Phase 1.1 (US-101), gate G2.
+ *
+ * Design constraints:
+ *   - This module defines the *verifier interface* (`ManifestVerifier`) but NOT
+ *     the implementation. ADR-0006 Sigstore verify lands in src/main/mcp/manifestVerify.ts
+ *     during Phase 2.2 (US-201). Phase 1 must remain Sigstore-import-free so that
+ *     the @sigstore/verify spike (US-200) can independently fail without blocking
+ *     Phase 1 work. (codex consolidation: "Phase 1 verifier interface is decoupled".)
+ *   - signing.identity is the *publisher claim* — what the publisher promises the
+ *     Sigstore cert will say. Verification matches actual cert claims against this
+ *     promise. Mismatch in `strict` mode = reject (G2 codex tightening: "signature
+ *     without identity policy is theater").
+ */
+
+import { z } from 'zod';
+import type { InstalledPluginRecord } from './installedPluginRecord';
+
+// ────────────────────────────────────────────────────────────
+// Sub-schemas
+// ────────────────────────────────────────────────────────────
+
+const Sha256HexSchema = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
+
+const SemverSchema = z
+  .string()
+  .regex(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
+    'Must be semver',
+  );
+
+const PackageIdSchema = z
+  .string()
+  .min(1)
+  .max(214)
+  .regex(/^(@[a-zA-Z0-9][a-zA-Z0-9_-]*\/)?[a-zA-Z0-9][a-zA-Z0-9_-]*$/, 'Invalid package id');
+
+/**
+ * Capability string. Free-form for now (e.g. `host.fs.read`, `host.audit.write`,
+ * `host.session.subscribe`). McpCapabilityGate validates against host-side
+ * registry of known capabilities at grant time.
+ */
+const CapabilitySchema = z.string().min(1).max(128).regex(/^[a-z]+(\.[a-z_]+)+$/);
+
+/**
+ * Signing method. Only `sigstore-keyless-oidc` for v2.3.0. Future methods (e.g.
+ * `pgp`, `ed25519-static`) require ADR + manifest schema migration.
+ */
+const SigningMethodSchema = z.enum(['sigstore-keyless-oidc']);
+
+/**
+ * Identity policy claim — what the publisher promises about the Sigstore cert.
+ * verifier compares actual cert.iss vs promised issuer (URL-equal) and
+ * actual cert.sub vs promised subject_pattern (glob match).
+ *
+ * Examples:
+ *   - issuer: "https://token.actions.githubusercontent.com"
+ *   - subject_pattern: "repo:eonofpixel/sample-plugin:ref:refs/tags/v*"
+ */
+const SigningIdentitySchema = z
+  .object({
+    issuer: z.string().url(),
+    subject_pattern: z.string().min(1).max(512),
+  })
+  .strict();
+
+const SigningSchema = z
+  .object({
+    method: SigningMethodSchema,
+    identity: SigningIdentitySchema,
+  })
+  .strict();
+
+/**
+ * Runtime metadata. Used by host to decide isolation_mode default and to surface
+ * incompatibility warnings (e.g. "this plugin requires native modules; consider
+ * setting isolation_mode = in_process").
+ */
+const RuntimeSchema = z
+  .object({
+    /** Node major version range plugin supports (e.g. "^18.0.0 || ^20.0.0"). */
+    node: z.string().min(1).max(128),
+    /** True if plugin uses native (.node) modules — affects utility_process compat. */
+    requires_native_modules: z.boolean().default(false),
+    /** Plugin-declared default isolation. Host honors as suggestion only. */
+    preferred_isolation: z.enum(['utility_process', 'in_process']).optional(),
+  })
+  .strict();
+
+/**
+ * Entrypoint metadata — describes the runnable artifact the manifest binds.
+ */
+const EntrypointSchema = z
+  .object({
+    /** Filename within the artifact tarball (e.g. "dist/index.js"). */
+    file: z.string().min(1).max(256),
+    /** sha256 of the artifact tarball. Verifier confirms before extraction. */
+    artifact_digest: Sha256HexSchema,
+    /** Bytes of the artifact tarball. Sanity check; does not replace digest. */
+    artifact_size_bytes: z.number().int().positive().max(50 * 1024 * 1024),
+  })
+  .strict();
+
+// ────────────────────────────────────────────────────────────
+// Main schema
+// ────────────────────────────────────────────────────────────
+
+export const McpManifestSchema = z
+  .object({
+    /** Manifest schema version. Bump on breaking changes. v2.3.0 ships v1. */
+    schema_version: z.literal(1),
+    package_id: PackageIdSchema,
+    name: z.string().min(1).max(128),
+    version: SemverSchema,
+    description: z.string().max(2048).optional(),
+    capabilities: z.array(CapabilitySchema).min(0).max(64),
+    entrypoint: EntrypointSchema,
+    signing: SigningSchema,
+    runtime: RuntimeSchema,
+  })
+  .strict();
+
+export type McpManifest = z.infer<typeof McpManifestSchema>;
+
+// ────────────────────────────────────────────────────────────
+// Verifier interface (implementation lands in Phase 2.2 / US-201)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Outcome of a manifest verification attempt. The `evidence` field carries
+ * provenance (cert subject, issuer, log index) for audit log + UI surface.
+ */
+export type ManifestVerificationResult =
+  | {
+      kind: 'verified';
+      evidence: {
+        cert_issuer: string;
+        cert_subject: string;
+        rekor_log_index?: number;
+        verified_at: string;
+      };
+    }
+  | {
+      kind: 'identity_mismatch';
+      evidence: {
+        expected_issuer: string;
+        actual_issuer: string;
+        expected_subject_pattern: string;
+        actual_subject: string;
+      };
+    }
+  | {
+      kind: 'signature_invalid';
+      evidence: {
+        reason: string;
+      };
+    }
+  | {
+      kind: 'unsigned';
+      evidence: {
+        reason: 'no_bundle' | 'mode_off';
+      };
+    };
+
+/**
+ * mcpVerificationMode — set by user in settings (G2 resolution).
+ * Default `strict`. Verifier behavior:
+ *   - strict: identity_mismatch / signature_invalid / unsigned-no-bundle = reject install
+ *   - warn: same conditions = audit-warn-allow
+ *   - off: skip verify entirely (returns kind='unsigned' evidence='mode_off')
+ */
+export type McpVerificationMode = 'strict' | 'warn' | 'off';
+
+/**
+ * ManifestVerifier — implementation injected by Phase 2.2.
+ *
+ * Phase 1 code that needs to *invoke* verification depends on this interface,
+ * not on the Sigstore implementation. This keeps Phase 1 (US-101..US-105)
+ * parallel-safe with the @sigstore/verify spike (US-200).
+ */
+export interface ManifestVerifier {
+  /**
+   * Verify a manifest against an attached Sigstore bundle (or absence thereof).
+   *
+   * @param manifest parsed McpManifest (must have passed schema validation prior)
+   * @param sigstoreBundle raw Sigstore bundle JSON, or null if unsigned
+   * @param mode user-selected verification mode
+   * @returns verification result; caller decides install/reject based on mode
+   */
+  verify(
+    manifest: McpManifest,
+    sigstoreBundle: unknown | null,
+    mode: McpVerificationMode,
+  ): Promise<ManifestVerificationResult>;
+}
+
+/**
+ * Project a verified manifest + verification result into the partial fields of
+ * an InstalledPluginRecord that this layer is responsible for. The caller fills
+ * in install-time-only fields (installed_at, isolation_mode, revocation_status).
+ */
+export function manifestToRecordPartial(
+  manifest: McpManifest,
+  manifestDigest: string,
+  result: ManifestVerificationResult,
+): Pick<
+  InstalledPluginRecord,
+  'package_id' | 'publisher_id' | 'version' | 'artifact_digest' | 'manifest_digest' | 'verification_status' | 'last_verified_at'
+> {
+  const publisher_id =
+    result.kind === 'verified'
+      ? `${new URL(result.evidence.cert_issuer).host}:${result.evidence.cert_subject}`
+      : `${new URL(manifest.signing.identity.issuer).host}:${manifest.signing.identity.subject_pattern}`;
+
+  const verification_status: InstalledPluginRecord['verification_status'] =
+    result.kind === 'verified'
+      ? 'verified'
+      : result.kind === 'identity_mismatch'
+        ? 'identity_mismatch'
+        : result.kind === 'signature_invalid'
+          ? 'signature_invalid'
+          : 'unverified';
+
+  const last_verified_at = result.kind === 'verified' ? result.evidence.verified_at : null;
+
+  return {
+    package_id: manifest.package_id,
+    publisher_id,
+    version: manifest.version,
+    artifact_digest: manifest.entrypoint.artifact_digest,
+    manifest_digest: manifestDigest,
+    verification_status,
+    last_verified_at,
+  };
+}

--- a/src/types/mcpManifest.ts
+++ b/src/types/mcpManifest.ts
@@ -27,15 +27,13 @@ import type { InstalledPluginRecord } from './installedPluginRecord';
 // Sub-schemas
 // ────────────────────────────────────────────────────────────
 
-const Sha256HexSchema = z
-  .string()
-  .regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
+const Sha256HexSchema = z.string().regex(/^[0-9a-f]{64}$/, 'Must be lowercase 64-char sha256 hex');
 
 const SemverSchema = z
   .string()
   .regex(
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
-    'Must be semver',
+    'Must be semver'
   );
 
 const PackageIdSchema = z
@@ -49,7 +47,11 @@ const PackageIdSchema = z
  * `host.session.subscribe`). McpCapabilityGate validates against host-side
  * registry of known capabilities at grant time.
  */
-const CapabilitySchema = z.string().min(1).max(128).regex(/^[a-z]+(\.[a-z_]+)+$/);
+const CapabilitySchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-z]+(\.[a-z_]+)+$/);
 
 /**
  * Signing method. Only `sigstore-keyless-oidc` for v2.3.0. Future methods (e.g.
@@ -106,7 +108,11 @@ const EntrypointSchema = z
     /** sha256 of the artifact tarball. Verifier confirms before extraction. */
     artifact_digest: Sha256HexSchema,
     /** Bytes of the artifact tarball. Sanity check; does not replace digest. */
-    artifact_size_bytes: z.number().int().positive().max(50 * 1024 * 1024),
+    artifact_size_bytes: z
+      .number()
+      .int()
+      .positive()
+      .max(50 * 1024 * 1024),
   })
   .strict();
 
@@ -199,7 +205,7 @@ export interface ManifestVerifier {
   verify(
     manifest: McpManifest,
     sigstoreBundle: unknown | null,
-    mode: McpVerificationMode,
+    mode: McpVerificationMode
   ): Promise<ManifestVerificationResult>;
 }
 
@@ -211,10 +217,16 @@ export interface ManifestVerifier {
 export function manifestToRecordPartial(
   manifest: McpManifest,
   manifestDigest: string,
-  result: ManifestVerificationResult,
+  result: ManifestVerificationResult
 ): Pick<
   InstalledPluginRecord,
-  'package_id' | 'publisher_id' | 'version' | 'artifact_digest' | 'manifest_digest' | 'verification_status' | 'last_verified_at'
+  | 'package_id'
+  | 'publisher_id'
+  | 'version'
+  | 'artifact_digest'
+  | 'manifest_digest'
+  | 'verification_status'
+  | 'last_verified_at'
 > {
   const publisher_id =
     result.kind === 'verified'

--- a/tests/main/mcp/McpCapabilityGate.test.ts
+++ b/tests/main/mcp/McpCapabilityGate.test.ts
@@ -1,0 +1,202 @@
+/**
+ * McpCapabilityGate tests (v2.3.0 US-102).
+ *
+ * Verifies:
+ *   - grant→isGranted true; revoke→isGranted false (AC mirror PluginCapabilityGate API)
+ *   - grant_epoch monotonic on revoke (G5 sync invalidation precursor)
+ *   - File persistence + reload on new instance (production-like flow)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpCapabilityGate } from '../../../src/main/mcp/McpCapabilityGate';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'mcp-cap-gate-'));
+});
+
+afterEach(() => {
+  if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('v2.3.0 US-102 — McpCapabilityGate basic API', () => {
+  it('grantOne → isGranted returns true', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.isGranted('server-a', 'host.fs.read')).toBe(true);
+  });
+
+  it('revokeOne(cap) → isGranted returns false', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.revokeOne('server-a', 'host.fs.read');
+    expect(gate.isGranted('server-a', 'host.fs.read')).toBe(false);
+  });
+
+  it('listGranted returns sorted capabilities', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.write');
+    gate.grantOne('server-a', 'host.audit.write');
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.listGranted('server-a')).toEqual([
+      'host.audit.write',
+      'host.fs.read',
+      'host.fs.write',
+    ]);
+  });
+
+  it('listGranted returns [] for unknown server', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate.listGranted('never-touched')).toEqual([]);
+  });
+
+  it('revokeOne(undefined) clears all capabilities', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.grantOne('server-a', 'host.audit.write');
+    gate.revokeOne('server-a');
+    expect(gate.listGranted('server-a')).toEqual([]);
+  });
+
+  it('grantOne is idempotent (no audit duplicates)', () => {
+    const events: string[] = [];
+    const gate = new McpCapabilityGate({
+      storageDir: tmpRoot,
+      auditSink: (e) => events.push(e.event),
+    });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(events.filter((e) => e === 'mcp.cap_granted').length).toBe(1);
+  });
+});
+
+describe('v2.3.0 US-102 — grant_epoch monotonicity (G5)', () => {
+  it('initial epoch is 0', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate.getGrantEpoch('server-a')).toBe(0);
+  });
+
+  it('grantOne does NOT bump epoch (only revoke does)', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.getGrantEpoch('server-a')).toBe(0);
+    gate.grantOne('server-a', 'host.audit.write');
+    expect(gate.getGrantEpoch('server-a')).toBe(0);
+  });
+
+  it('revokeOne(cap) increments epoch by 1', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.revokeOne('server-a', 'host.fs.read');
+    expect(gate.getGrantEpoch('server-a')).toBe(1);
+  });
+
+  it('revokeOne(undefined) increments epoch by 1', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.revokeOne('server-a');
+    expect(gate.getGrantEpoch('server-a')).toBe(1);
+  });
+
+  it('multiple revokes are strictly monotonic (no gaps)', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.revokeOne('server-a', 'host.fs.read')).toBe(1);
+    expect(gate.revokeOne('server-a', 'host.audit.write')).toBe(2);
+    expect(gate.revokeOne('server-a')).toBe(3);
+  });
+
+  it('revoking ungranted capability still bumps epoch (defensive monotonic)', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate.revokeOne('server-a', 'host.fs.read')).toBe(1);
+  });
+});
+
+describe('v2.3.0 US-102 — persistence', () => {
+  it('grant persists to disk and reloads on new instance', () => {
+    const gate1 = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate1.grantOne('server-a', 'host.fs.read');
+    gate1.grantOne('server-a', 'host.audit.write');
+
+    const gate2 = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate2.isGranted('server-a', 'host.fs.read')).toBe(true);
+    expect(gate2.isGranted('server-a', 'host.audit.write')).toBe(true);
+    expect(gate2.listGranted('server-a')).toEqual(['host.audit.write', 'host.fs.read']);
+  });
+
+  it('grant_epoch persists across instances', () => {
+    const gate1 = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate1.grantOne('server-a', 'host.fs.read');
+    gate1.revokeOne('server-a', 'host.fs.read');
+    gate1.grantOne('server-a', 'host.audit.write');
+    expect(gate1.getGrantEpoch('server-a')).toBe(1);
+
+    const gate2 = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate2.getGrantEpoch('server-a')).toBe(1);
+  });
+
+  it('revokeOne(undefined) deletes the persistence file', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(existsSync(join(tmpRoot, 'server-a', 'granted.json'))).toBe(true);
+    gate.revokeOne('server-a');
+    expect(existsSync(join(tmpRoot, 'server-a', 'granted.json'))).toBe(false);
+  });
+
+  it('persisted file shape: { capabilities: sorted[], grant_epoch: number }', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.write');
+    gate.grantOne('server-a', 'host.audit.write');
+    gate.grantOne('server-a', 'host.fs.read');
+    const raw = readFileSync(join(tmpRoot, 'server-a', 'granted.json'), 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data.capabilities).toEqual(['host.audit.write', 'host.fs.read', 'host.fs.write']);
+    expect(typeof data.grant_epoch).toBe('number');
+  });
+
+  it('corrupt JSON file is silently skipped on load (graceful degrade)', () => {
+    const serverDir = join(tmpRoot, 'broken-server');
+    mkdirSyncSafe(serverDir);
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.writeFileSync(join(serverDir, 'granted.json'), '{ not: valid json', 'utf-8');
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    expect(gate.isGranted('broken-server', 'anything')).toBe(false);
+    expect(gate.getGrantEpoch('broken-server')).toBe(0);
+  });
+});
+
+function mkdirSyncSafe(p: string): void {
+  const fs = require('node:fs') as typeof import('node:fs');
+  fs.mkdirSync(p, { recursive: true });
+}
+
+describe('v2.3.0 US-102 — multi-server isolation', () => {
+  it('grant on server-a does not leak to server-b', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.isGranted('server-b', 'host.fs.read')).toBe(false);
+  });
+
+  it('revoke on server-a does not bump epoch on server-b', () => {
+    const gate = new McpCapabilityGate({ storageDir: tmpRoot });
+    gate.grantOne('server-a', 'host.fs.read');
+    gate.grantOne('server-b', 'host.fs.read');
+    gate.revokeOne('server-a', 'host.fs.read');
+    expect(gate.getGrantEpoch('server-a')).toBe(1);
+    expect(gate.getGrantEpoch('server-b')).toBe(0);
+  });
+});
+
+describe('v2.3.0 US-102 — in-memory mode (no storageDir)', () => {
+  it('works without storageDir (no persistence)', () => {
+    const gate = new McpCapabilityGate();
+    gate.grantOne('server-a', 'host.fs.read');
+    expect(gate.isGranted('server-a', 'host.fs.read')).toBe(true);
+    expect(gate.revokeOne('server-a', 'host.fs.read')).toBe(1);
+    expect(gate.isGranted('server-a', 'host.fs.read')).toBe(false);
+  });
+});

--- a/tests/main/mcp/McpCapabilityGate.test.ts
+++ b/tests/main/mcp/McpCapabilityGate.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { McpCapabilityGate } from '../../../src/main/mcp/McpCapabilityGate';
@@ -160,19 +160,13 @@ describe('v2.3.0 US-102 — persistence', () => {
 
   it('corrupt JSON file is silently skipped on load (graceful degrade)', () => {
     const serverDir = join(tmpRoot, 'broken-server');
-    mkdirSyncSafe(serverDir);
-    const fs = require('node:fs') as typeof import('node:fs');
-    fs.writeFileSync(join(serverDir, 'granted.json'), '{ not: valid json', 'utf-8');
+    mkdirSync(serverDir, { recursive: true });
+    writeFileSync(join(serverDir, 'granted.json'), '{ not: valid json', 'utf-8');
     const gate = new McpCapabilityGate({ storageDir: tmpRoot });
     expect(gate.isGranted('broken-server', 'anything')).toBe(false);
     expect(gate.getGrantEpoch('broken-server')).toBe(0);
   });
 });
-
-function mkdirSyncSafe(p: string): void {
-  const fs = require('node:fs') as typeof import('node:fs');
-  fs.mkdirSync(p, { recursive: true });
-}
 
 describe('v2.3.0 US-102 — multi-server isolation', () => {
   it('grant on server-a does not leak to server-b', () => {

--- a/tests/main/mcp/conflictResolver.test.ts
+++ b/tests/main/mcp/conflictResolver.test.ts
@@ -16,17 +16,14 @@ describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
     });
 
     it('exact match request ⊆ granted → allow', () => {
-      const r = resolveCapabilityConflict(
-        ['host.fs.read'],
-        ['host.fs.read', 'host.audit.write'],
-      );
+      const r = resolveCapabilityConflict(['host.fs.read'], ['host.fs.read', 'host.audit.write']);
       expect(r.kind).toBe('allow');
     });
 
     it('subset request ⊆ granted → allow', () => {
       const r = resolveCapabilityConflict(
         ['host.fs.read', 'host.audit.write'],
-        ['host.fs.read', 'host.fs.write', 'host.audit.write'],
+        ['host.fs.read', 'host.fs.write', 'host.audit.write']
       );
       expect(r.kind).toBe('allow');
     });
@@ -47,11 +44,9 @@ describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
     });
 
     it('mix of allowed + denied → deny (deny precedence)', () => {
-      const r = resolveCapabilityConflict(
-        ['host.fs.read', 'host.shell.exec'],
-        ['host.fs.read'],
-        { deniedCapabilities: denied },
-      );
+      const r = resolveCapabilityConflict(['host.fs.read', 'host.shell.exec'], ['host.fs.read'], {
+        deniedCapabilities: denied,
+      });
       expect(r.kind).toBe('deny');
       if (r.kind === 'deny') {
         expect(r.offending).toEqual(['host.shell.exec']);
@@ -59,11 +54,9 @@ describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
     });
 
     it('multiple denied capabilities → all reported in offending', () => {
-      const r = resolveCapabilityConflict(
-        ['host.shell.exec', 'host.network.bind'],
-        [],
-        { deniedCapabilities: new Set(['host.shell.exec', 'host.network.bind']) },
-      );
+      const r = resolveCapabilityConflict(['host.shell.exec', 'host.network.bind'], [], {
+        deniedCapabilities: new Set(['host.shell.exec', 'host.network.bind']),
+      });
       expect(r.kind).toBe('deny');
       if (r.kind === 'deny') {
         expect(r.offending).toEqual(['host.shell.exec', 'host.network.bind']);
@@ -82,10 +75,7 @@ describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
     });
 
     it('partial overlap → consent for the new ones only', () => {
-      const r = resolveCapabilityConflict(
-        ['host.fs.read', 'host.audit.write'],
-        ['host.fs.read'],
-      );
+      const r = resolveCapabilityConflict(['host.fs.read', 'host.audit.write'], ['host.fs.read']);
       expect(r.kind).toBe('requires_user_consent');
       if (r.kind === 'requires_user_consent') {
         expect(r.new_capabilities).toEqual(['host.audit.write']);
@@ -95,7 +85,7 @@ describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
     it('all new (disjoint) → consent for all requested', () => {
       const r = resolveCapabilityConflict(
         ['host.audit.write', 'host.session.subscribe'],
-        ['host.fs.read'],
+        ['host.fs.read']
       );
       expect(r.kind).toBe('requires_user_consent');
       if (r.kind === 'requires_user_consent') {

--- a/tests/main/mcp/conflictResolver.test.ts
+++ b/tests/main/mcp/conflictResolver.test.ts
@@ -1,0 +1,106 @@
+/**
+ * conflictResolver tests (v2.3.0 US-103).
+ *
+ * 9-case matrix: 3 input shapes × 3 outcome categories.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveCapabilityConflict } from '../../../src/main/mcp/conflictResolver';
+
+describe('v2.3.0 US-103 — resolveCapabilityConflict', () => {
+  // ── allow row (superset already granted) ────────────────────────────
+  describe('allow', () => {
+    it('empty request + empty granted → allow', () => {
+      const r = resolveCapabilityConflict([], []);
+      expect(r.kind).toBe('allow');
+    });
+
+    it('exact match request ⊆ granted → allow', () => {
+      const r = resolveCapabilityConflict(
+        ['host.fs.read'],
+        ['host.fs.read', 'host.audit.write'],
+      );
+      expect(r.kind).toBe('allow');
+    });
+
+    it('subset request ⊆ granted → allow', () => {
+      const r = resolveCapabilityConflict(
+        ['host.fs.read', 'host.audit.write'],
+        ['host.fs.read', 'host.fs.write', 'host.audit.write'],
+      );
+      expect(r.kind).toBe('allow');
+    });
+  });
+
+  // ── deny row (deny list policy violation) ───────────────────────────
+  describe('deny', () => {
+    const denied = new Set(['host.shell.exec']);
+
+    it('single denied capability requested → deny with offender list', () => {
+      const r = resolveCapabilityConflict(['host.shell.exec'], [], {
+        deniedCapabilities: denied,
+      });
+      expect(r.kind).toBe('deny');
+      if (r.kind === 'deny') {
+        expect(r.offending).toEqual(['host.shell.exec']);
+      }
+    });
+
+    it('mix of allowed + denied → deny (deny precedence)', () => {
+      const r = resolveCapabilityConflict(
+        ['host.fs.read', 'host.shell.exec'],
+        ['host.fs.read'],
+        { deniedCapabilities: denied },
+      );
+      expect(r.kind).toBe('deny');
+      if (r.kind === 'deny') {
+        expect(r.offending).toEqual(['host.shell.exec']);
+      }
+    });
+
+    it('multiple denied capabilities → all reported in offending', () => {
+      const r = resolveCapabilityConflict(
+        ['host.shell.exec', 'host.network.bind'],
+        [],
+        { deniedCapabilities: new Set(['host.shell.exec', 'host.network.bind']) },
+      );
+      expect(r.kind).toBe('deny');
+      if (r.kind === 'deny') {
+        expect(r.offending).toEqual(['host.shell.exec', 'host.network.bind']);
+      }
+    });
+  });
+
+  // ── consent row (new capabilities, not denied) ──────────────────────
+  describe('requires_user_consent', () => {
+    it('new capability with empty grant → consent for new', () => {
+      const r = resolveCapabilityConflict(['host.fs.read'], []);
+      expect(r.kind).toBe('requires_user_consent');
+      if (r.kind === 'requires_user_consent') {
+        expect(r.new_capabilities).toEqual(['host.fs.read']);
+      }
+    });
+
+    it('partial overlap → consent for the new ones only', () => {
+      const r = resolveCapabilityConflict(
+        ['host.fs.read', 'host.audit.write'],
+        ['host.fs.read'],
+      );
+      expect(r.kind).toBe('requires_user_consent');
+      if (r.kind === 'requires_user_consent') {
+        expect(r.new_capabilities).toEqual(['host.audit.write']);
+      }
+    });
+
+    it('all new (disjoint) → consent for all requested', () => {
+      const r = resolveCapabilityConflict(
+        ['host.audit.write', 'host.session.subscribe'],
+        ['host.fs.read'],
+      );
+      expect(r.kind).toBe('requires_user_consent');
+      if (r.kind === 'requires_user_consent') {
+        expect(r.new_capabilities).toEqual(['host.audit.write', 'host.session.subscribe']);
+      }
+    });
+  });
+});

--- a/tests/types/mcpManifest.test.ts
+++ b/tests/types/mcpManifest.test.ts
@@ -102,7 +102,7 @@ describe('v2.3.0 US-101 — manifestToRecordPartial', () => {
     expect(partial.verification_status).toBe('verified');
     expect(partial.last_verified_at).toBe('2026-05-09T12:00:00.000Z');
     expect(partial.publisher_id).toBe(
-      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v1.2.3',
+      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v1.2.3'
     );
     expect(partial.package_id).toBe('@eonofpixel/sample-mcp');
     expect(partial.version).toBe('1.2.3');
@@ -123,7 +123,7 @@ describe('v2.3.0 US-101 — manifestToRecordPartial', () => {
     expect(partial.verification_status).toBe('identity_mismatch');
     expect(partial.last_verified_at).toBeNull();
     expect(partial.publisher_id).toBe(
-      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v*',
+      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v*'
     );
   });
 

--- a/tests/types/mcpManifest.test.ts
+++ b/tests/types/mcpManifest.test.ts
@@ -1,0 +1,149 @@
+/**
+ * McpManifest schema tests (v2.3.0 US-101).
+ *
+ * Validates: 1 valid fixture + 5 invalid fixtures rejected (US-101 AC).
+ * Plus: manifestToRecordPartial projection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  McpManifestSchema,
+  manifestToRecordPartial,
+  type ManifestVerificationResult,
+} from '../../src/types/mcpManifest';
+
+const validFixture = {
+  schema_version: 1 as const,
+  package_id: '@eonofpixel/sample-mcp',
+  name: 'Sample MCP Server',
+  version: '1.2.3',
+  description: 'Example MCP server for v2.3.0 marketplace tests.',
+  capabilities: ['host.fs.read', 'host.audit.write'],
+  entrypoint: {
+    file: 'dist/index.js',
+    artifact_digest: 'a'.repeat(64),
+    artifact_size_bytes: 1024,
+  },
+  signing: {
+    method: 'sigstore-keyless-oidc' as const,
+    identity: {
+      issuer: 'https://token.actions.githubusercontent.com',
+      subject_pattern: 'repo:eonofpixel/sample-mcp:ref:refs/tags/v*',
+    },
+  },
+  runtime: {
+    node: '^18.0.0 || ^20.0.0',
+    requires_native_modules: false,
+  },
+};
+
+describe('v2.3.0 US-101 — McpManifestSchema', () => {
+  it('accepts a valid manifest', () => {
+    const result = McpManifestSchema.safeParse(validFixture);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects manifest with unknown top-level field (.strict)', () => {
+    const broken = { ...validFixture, malicious_extra: 'sneaky' };
+    const result = McpManifestSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects manifest with non-semver version', () => {
+    const broken = { ...validFixture, version: 'latest' };
+    const result = McpManifestSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects manifest with non-https issuer', () => {
+    const broken = {
+      ...validFixture,
+      signing: {
+        ...validFixture.signing,
+        identity: {
+          issuer: 'not-a-url',
+          subject_pattern: validFixture.signing.identity.subject_pattern,
+        },
+      },
+    };
+    const result = McpManifestSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects manifest with malformed sha256 (must be lowercase 64-char hex)', () => {
+    const broken = {
+      ...validFixture,
+      entrypoint: { ...validFixture.entrypoint, artifact_digest: 'TOOSHORT' },
+    };
+    const result = McpManifestSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects manifest with capability not matching dotted-snake pattern', () => {
+    const broken = { ...validFixture, capabilities: ['HostFsRead'] };
+    const result = McpManifestSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('v2.3.0 US-101 — manifestToRecordPartial', () => {
+  const manifestDigest = 'b'.repeat(64);
+
+  it('verified result → publisher_id from cert claims, last_verified_at set', () => {
+    const result: ManifestVerificationResult = {
+      kind: 'verified',
+      evidence: {
+        cert_issuer: 'https://token.actions.githubusercontent.com',
+        cert_subject: 'repo:eonofpixel/sample-mcp:ref:refs/tags/v1.2.3',
+        verified_at: '2026-05-09T12:00:00.000Z',
+      },
+    };
+    const partial = manifestToRecordPartial(validFixture, manifestDigest, result);
+    expect(partial.verification_status).toBe('verified');
+    expect(partial.last_verified_at).toBe('2026-05-09T12:00:00.000Z');
+    expect(partial.publisher_id).toBe(
+      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v1.2.3',
+    );
+    expect(partial.package_id).toBe('@eonofpixel/sample-mcp');
+    expect(partial.version).toBe('1.2.3');
+    expect(partial.manifest_digest).toBe(manifestDigest);
+  });
+
+  it('identity_mismatch result → status mapped, publisher_id from manifest claim (not cert)', () => {
+    const result: ManifestVerificationResult = {
+      kind: 'identity_mismatch',
+      evidence: {
+        expected_issuer: 'https://token.actions.githubusercontent.com',
+        actual_issuer: 'https://token.actions.githubusercontent.com',
+        expected_subject_pattern: 'repo:eonofpixel/sample-mcp:ref:refs/tags/v*',
+        actual_subject: 'repo:malicious/typosquat:ref:refs/heads/main',
+      },
+    };
+    const partial = manifestToRecordPartial(validFixture, manifestDigest, result);
+    expect(partial.verification_status).toBe('identity_mismatch');
+    expect(partial.last_verified_at).toBeNull();
+    expect(partial.publisher_id).toBe(
+      'token.actions.githubusercontent.com:repo:eonofpixel/sample-mcp:ref:refs/tags/v*',
+    );
+  });
+
+  it('signature_invalid result → status mapped, last_verified_at null', () => {
+    const result: ManifestVerificationResult = {
+      kind: 'signature_invalid',
+      evidence: { reason: 'Sigstore bundle digest mismatch' },
+    };
+    const partial = manifestToRecordPartial(validFixture, manifestDigest, result);
+    expect(partial.verification_status).toBe('signature_invalid');
+    expect(partial.last_verified_at).toBeNull();
+  });
+
+  it('unsigned result → status=unverified, last_verified_at null', () => {
+    const result: ManifestVerificationResult = {
+      kind: 'unsigned',
+      evidence: { reason: 'mode_off' },
+    };
+    const partial = manifestToRecordPartial(validFixture, manifestDigest, result);
+    expect(partial.verification_status).toBe('unverified');
+    expect(partial.last_verified_at).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the v2.3.0 Plugin GA cycle — 6/6 user stories pass. Lands the cross-phase identity record, MCP manifest schema with verifier interface, McpCapabilityGate with grant_epoch (G5 sync-invalidation precursor), conflict resolver, preload bridge surface, and migration doc skeleton.

This is foundation-only — Sigstore verification, signed revocation feed, marketplace UI, dispatcher, worker pool, and PR #33 redo land in subsequent phases.

## What landed

- **US-100** `src/types/installedPluginRecord.ts` — single-source-of-truth record (zod `.strict()`, 11 fields, 3 enums). Closes codex hidden-coupling concern.
- **US-101** `src/types/mcpManifest.ts` — `McpManifestSchema` + `ManifestVerifier` interface. signing.identity (issuer + subject_pattern) wired but Sigstore import deferred to Phase 2.2 → keeps Phase 1 parallel-safe with US-200 spike.
- **US-102** `src/main/mcp/McpCapabilityGate.ts` — API mirror of `PluginCapabilityGate` (grant/revoke/isGranted/list) + monotonic `grant_epoch`. File persistence at `<storageDir>/<server_id>/granted.json`. Forgiving JSON load.
- **US-103** `src/main/mcp/conflictResolver.ts` — `{ allow | deny | requires_user_consent }`. Deny precedence over consent.
- **US-104** `src/main/preload.ts` — extended `mcp` namespace with `listInstalled` / `getRecord` / `requestRevoke` (returns `{ grant_epoch }` so renderer caches sync without poll) / `requestRefreshRevocations`. 4 channels added to `ALLOWED_INVOKE_CHANNELS`.
- **US-105** `docs/migration/v2.2-to-v2.3.md` — skeleton, 7 sections marked TODO(Phase 7).

## Tests

- `tests/types/mcpManifest.test.ts` — 10 cases (1 valid + 5 invalid manifest fixtures + 4 `manifestToRecordPartial` projections)
- `tests/main/mcp/conflictResolver.test.ts` — 9-case matrix (3 allow + 3 deny + 3 consent)
- `tests/main/mcp/McpCapabilityGate.test.ts` — 20 cases (basic API 6, grant_epoch monotonicity 6, persistence 5, multi-server isolation 2, in-memory mode 1)

**Total: 39 new tests, all green.**

## Verification

- [x] `npm run typecheck` → 0 errors
- [x] `npx vitest run` (Phase 1 batch) → 39/39 pass
- [ ] e2e — N/A for Phase 1 (foundation types + preload surface only)
- [ ] axe — N/A for Phase 1

## G-ref coverage

| Gate | Phase 1 contribution | Full landing phase |
|------|----------------------|---------------------|
| G1 (worker pool) | `isolation_mode` field on record | Phase 5 (US-500..506) |
| G2 (Sigstore identity policy) | `signing.identity` schema + verifier interface | Phase 2 (US-200..205) |
| G3 (signed revocation feed) | `revocation_status` field | Phase 2.4 (US-203) |
| G4 (utility_process default) | `isolation_mode='utility_process'` default | Phase 6 (US-600..606) |
| G5 (priority lane revoke) | `grant_epoch` monotonic counter | Phase 4.4 (US-403) |
| G6 (per-plugin override) | isolation_mode override values | Phase 3 + 6 |

## Test plan

- [x] Phase 1 unit tests green
- [x] preload.ts typecheck after additive edit
- [ ] Smoke after merge: open dev build, confirm `window.dreampia.mcp.listInstalled` is exposed (will return Result with empty array since main-process handler not yet wired — that lands in Phase 3/4)

## References

- Plan: `.omc/plans/v2.3.0-plugin-ga.md` (r3 codex-consolidated)
- Predecessor: v2.2.0 (9e6ac6f) — architectural foundations
- ADRs invoked: 0003 (utility_process), 0004 (IPC bridge), 0006 (MCP capability negotiation). ADR-0009 (worker lifecycle) drafted in Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)