### PR TITLE
feat(v2.4.0): InstalledPluginRecordStore + 4 mcp/* IPC handlers (marketplace UI backing)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2556,6 +2556,86 @@ function registerMcpHandlers(mcp: McpManager): void {
       return fail(err);
     }
   });
+
+  // ────────────────────────────────────────────────────────────
+  // v2.3.0 (US-104) — installed plugin record surface (marketplace UI).
+  // Lazy-init store at userData path. Records are written by the install
+  // path (v2.4.0); v2.3.x ships the read surface so the marketplace UI
+  // can fetch (returns empty array until install path lands).
+  // ────────────────────────────────────────────────────────────
+
+  let recordStore: import('./mcp/installedPluginRecordStore').InstalledPluginRecordStore | null =
+    null;
+  const getRecordStore = async (): Promise<
+    import('./mcp/installedPluginRecordStore').InstalledPluginRecordStore
+  > => {
+    if (recordStore !== null) return recordStore;
+    const { InstalledPluginRecordStore } = await import('./mcp/installedPluginRecordStore');
+    const userData = app.getPath('userData');
+    recordStore = new InstalledPluginRecordStore({
+      storageDir: path.join(userData, 'installed-plugin-records'),
+    });
+    return recordStore;
+  };
+
+  ipcMain.handle(
+    'mcp/list-installed',
+    async (): Promise<Result<import('@/types/installedPluginRecord').InstalledPluginRecord[]>> => {
+      try {
+        const store = await getRecordStore();
+        return ok(store.listAll());
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'mcp/get-record',
+    async (
+      _evt,
+      package_id: unknown
+    ): Promise<Result<import('@/types/installedPluginRecord').InstalledPluginRecord | null>> => {
+      try {
+        if (typeof package_id !== 'string' || package_id.length === 0) {
+          return fail(new Error('package_id required'));
+        }
+        const store = await getRecordStore();
+        return ok(store.get(package_id));
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'mcp/request-revoke',
+    async (_evt, server_id: unknown): Promise<Result<{ grant_epoch: number }>> => {
+      try {
+        if (typeof server_id !== 'string' || server_id.length === 0) {
+          return fail(new Error('server_id required'));
+        }
+        // v2.4.0 follow-up: route through McpCapabilityGate.revokeOne(server_id)
+        // + Pool.notifyRevoke. v2.3.x stub: returns epoch=0 since no Pool runs.
+        return ok({ grant_epoch: 0 });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'mcp/request-refresh-revocations',
+    async (): Promise<Result<{ applied: boolean; feed_version: number | null }>> => {
+      try {
+        // v2.4.0 follow-up: invoke signedRevocationFeed.applyOnce(). v2.3.x
+        // stub: no scheduler running → reports no-change.
+        return ok({ applied: false, feed_version: null });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
 }
 
 interface McpDiscoveryResult {

--- a/src/main/mcp/installedPluginRecordStore.ts
+++ b/src/main/mcp/installedPluginRecordStore.ts
@@ -1,0 +1,133 @@
+/**
+ * installedPluginRecordStore — file-based persistence for InstalledPluginRecord.
+ *
+ * Spec: v2.4.0 marketplace integration follow-up to v2.3.0 PRD.
+ *
+ * Storage layout: `<storageDir>/<package_id>.json` with one record per file.
+ * `storageDir` defaults to `~/.dreampia/installed-plugin-records/` (Electron
+ * `app.getPath('userData')` rooted in production).
+ *
+ * Forgiving load: corrupt JSON / schema-mismatch entries are silently skipped.
+ * `package_id` is encoded in the filename via URL-safe base64 to avoid path
+ * traversal and to support npm-scoped names like `@org/pkg`.
+ *
+ * No lockfile / atomic-rename — single-writer assumption (main process is the
+ * only caller). v2.4.0+ may add lockfile if multiple writers emerge.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+  InstalledPluginRecordSchema,
+  type InstalledPluginRecord,
+} from '../../types/installedPluginRecord';
+
+export interface InstalledPluginRecordStoreOptions {
+  /** Directory that holds `<package_id-encoded>.json` files. */
+  storageDir: string;
+}
+
+function encodePackageId(package_id: string): string {
+  // URL-safe base64 — no `/` or `+`, no padding. Reverses cleanly via
+  // decodePackageId for full round-trip.
+  return Buffer.from(package_id, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function decodePackageId(filename: string): string {
+  const base = filename.replace(/\.json$/, '');
+  const padded = base.replace(/-/g, '+').replace(/_/g, '/');
+  // Re-pad to multiple of 4
+  const pad = padded.length % 4;
+  const fullyPadded = pad === 0 ? padded : padded + '='.repeat(4 - pad);
+  return Buffer.from(fullyPadded, 'base64').toString('utf-8');
+}
+
+export class InstalledPluginRecordStore {
+  private readonly storageDir: string;
+
+  constructor(options: InstalledPluginRecordStoreOptions) {
+    this.storageDir = options.storageDir;
+    if (!existsSync(this.storageDir)) {
+      mkdirSync(this.storageDir, { recursive: true });
+    }
+  }
+
+  /** Persist (or overwrite) one record. */
+  put(record: InstalledPluginRecord): void {
+    const parsed = InstalledPluginRecordSchema.safeParse(record);
+    if (!parsed.success) {
+      throw new Error(`InstalledPluginRecordStore.put: invalid record: ${parsed.error.message}`);
+    }
+    const file = join(this.storageDir, `${encodePackageId(record.package_id)}.json`);
+    writeFileSync(file, JSON.stringify(parsed.data, null, 2), 'utf-8');
+  }
+
+  /** Read one record by package_id. Returns null if not found or corrupt. */
+  get(package_id: string): InstalledPluginRecord | null {
+    const file = join(this.storageDir, `${encodePackageId(package_id)}.json`);
+    if (!existsSync(file)) return null;
+    try {
+      const raw = readFileSync(file, 'utf-8');
+      const parsed = InstalledPluginRecordSchema.safeParse(JSON.parse(raw));
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** List every valid record. Corrupt entries silently skipped. */
+  listAll(): InstalledPluginRecord[] {
+    if (!existsSync(this.storageDir)) return [];
+    let entries: string[];
+    try {
+      entries = readdirSync(this.storageDir);
+    } catch {
+      return [];
+    }
+    const out: InstalledPluginRecord[] = [];
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      try {
+        const raw = readFileSync(join(this.storageDir, name), 'utf-8');
+        const parsed = InstalledPluginRecordSchema.safeParse(JSON.parse(raw));
+        if (parsed.success) out.push(parsed.data);
+      } catch {
+        // skip corrupt
+      }
+    }
+    return out;
+  }
+
+  /** Remove one record. No-op if not present. */
+  remove(package_id: string): void {
+    const file = join(this.storageDir, `${encodePackageId(package_id)}.json`);
+    if (!existsSync(file)) return;
+    try {
+      unlinkSync(file);
+    } catch {
+      // best effort
+    }
+  }
+
+  /** Test inspection — count of records on disk. */
+  count(): number {
+    return this.listAll().length;
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// Test helpers
+// ────────────────────────────────────────────────────────────
+
+export const __testing = { encodePackageId, decodePackageId };

--- a/tests/main/mcp/installedPluginRecordStore.test.ts
+++ b/tests/main/mcp/installedPluginRecordStore.test.ts
@@ -1,0 +1,111 @@
+/**
+ * InstalledPluginRecordStore tests (v2.4.0).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  InstalledPluginRecordStore,
+  __testing,
+} from '../../../src/main/mcp/installedPluginRecordStore';
+import type { InstalledPluginRecord } from '../../../src/types/installedPluginRecord';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'mcp-records-'));
+});
+
+afterEach(() => {
+  if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const sample: InstalledPluginRecord = {
+  package_id: '@eonofpixel/sample-mcp',
+  publisher_id: 'token.actions.githubusercontent.com:repo:eonofpixel/sample:ref:refs/tags/v1.0.0',
+  version: '1.0.0',
+  artifact_digest: 'a'.repeat(64),
+  manifest_digest: 'b'.repeat(64),
+  verification_status: 'verified',
+  revocation_status: 'clear',
+  isolation_mode: 'utility_process',
+  installed_at: '2026-05-09T00:00:00.000Z',
+  last_verified_at: '2026-05-09T00:00:00.000Z',
+  last_revocation_check_at: null,
+};
+
+describe('v2.4.0 — InstalledPluginRecordStore', () => {
+  it('put + get round-trip preserves all fields', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    store.put(sample);
+    const got = store.get(sample.package_id);
+    expect(got).toEqual(sample);
+  });
+
+  it('get returns null for unknown package_id', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    expect(store.get('@nope/none')).toBeNull();
+  });
+
+  it('listAll returns every persisted record', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    store.put(sample);
+    store.put({ ...sample, package_id: '@other/pkg' });
+    const list = store.listAll();
+    expect(list.length).toBe(2);
+    const ids = list.map((r) => r.package_id).sort();
+    expect(ids).toEqual(['@eonofpixel/sample-mcp', '@other/pkg']);
+  });
+
+  it('remove deletes the file; get returns null after', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    store.put(sample);
+    expect(store.count()).toBe(1);
+    store.remove(sample.package_id);
+    expect(store.count()).toBe(0);
+    expect(store.get(sample.package_id)).toBeNull();
+  });
+
+  it('put rejects records that fail schema validation', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    expect(() => store.put({ ...sample, version: 'not-semver' } as InstalledPluginRecord)).toThrow(
+      /invalid record/
+    );
+  });
+
+  it('listAll silently skips corrupt JSON files', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    store.put(sample);
+    writeFileSync(join(tmpRoot, 'broken.json'), '{ not: valid', 'utf-8');
+    const list = store.listAll();
+    expect(list.length).toBe(1);
+    expect(list[0]?.package_id).toBe('@eonofpixel/sample-mcp');
+  });
+
+  it('listAll silently skips schema-invalid records', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    store.put(sample);
+    writeFileSync(
+      join(tmpRoot, 'invalid.json'),
+      JSON.stringify({ package_id: 'x', version: 'bogus' }),
+      'utf-8'
+    );
+    const list = store.listAll();
+    expect(list.length).toBe(1);
+  });
+
+  it('package_id encoding round-trips for npm-scoped names', () => {
+    const enc = __testing.encodePackageId('@eonofpixel/sample-mcp');
+    expect(enc).not.toContain('/');
+    expect(enc).not.toContain('+');
+    expect(__testing.decodePackageId(enc + '.json')).toBe('@eonofpixel/sample-mcp');
+  });
+
+  it('handles empty storage dir gracefully (count=0)', () => {
+    const store = new InstalledPluginRecordStore({ storageDir: tmpRoot });
+    expect(store.count()).toBe(0);
+    expect(store.listAll()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the persistence + IPC surface needed for v2.3.0 marketplace UI components to actually fetch data. Components (`InstalledPluginList` / `RevokeModal` / `IsolationDowngradeModal`) were shipped in PR #41 but had no backing data source. This PR provides:

- File-based `InstalledPluginRecordStore` (one JSON per record at `<userData>/installed-plugin-records/<encoded-id>.json`)
- 4 IPC handlers: `mcp/list-installed`, `mcp/get-record`, `mcp/request-revoke`, `mcp/request-refresh-revocations`
- 9 unit tests

The IPC channels were already on the allowlist (PR #39) — this PR just registers the handlers + provides a backing store.

## Out of scope (v2.4.0 follow-ups)

- `request-revoke` and `request-refresh-revocations` are **stubs** until `PluginWorkerPool` and `signedRevocationFeed` are scheduled in main. Documented in code comments.
- Marketplace UI **mount** (in PluginsModal or new SettingsModal Plugin tab) is a separate next step — store + handlers are the prerequisite that's now in place.
- `Sigstore install path` (the actual `store.put()` caller) lands in v2.4.0 alongside Pool integration.

## Verification

- [x] `npm run typecheck` 0 errors
- [x] `npm run lint` 0 errors
- [x] `npx vitest run tests/main/mcp/installedPluginRecordStore.test.ts` — 9/9 pass
- [x] Prettier (CI scope) clean

## Tests

- round-trip put/get
- get null for unknown package_id
- listAll multi-record
- remove
- schema validation in put rejects bad records
- corrupt JSON skip in listAll
- schema-invalid skip in listAll
- npm-scoped package_id base64 encoding round-trip
- empty-dir count=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)